### PR TITLE
SOL-35152: Dependency Upgrades (Spring Boot 2.3.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.solace.spring.boot</groupId>
     <artifactId>solace-spring-boot-build</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot Build</name>
@@ -18,10 +18,10 @@
         <spring.boot.version>2.3.0.RELEASE</spring.boot.version>
         <pivotal.cfenv.version>2.1.2.RELEASE</pivotal.cfenv.version>
 
-        <solace.spring.boot.java-starter.version>4.0.1-SNAPSHOT</solace.spring.boot.java-starter.version>
-        <solace.spring.boot.jms-starter.version>4.0.1-SNAPSHOT</solace.spring.boot.jms-starter.version>
-        <solace.spring.boot.starter.version>1.0.1-SNAPSHOT</solace.spring.boot.starter.version>
-        <solace.cloud.cloudfoundry.java-cfenv.version>1.0.1-SNAPSHOT</solace.cloud.cloudfoundry.java-cfenv.version>
+        <solace.spring.boot.java-starter.version>4.1.0-SNAPSHOT</solace.spring.boot.java-starter.version>
+        <solace.spring.boot.jms-starter.version>4.1.0-SNAPSHOT</solace.spring.boot.jms-starter.version>
+        <solace.spring.boot.starter.version>1.1.0-SNAPSHOT</solace.spring.boot.starter.version>
+        <solace.cloud.cloudfoundry.java-cfenv.version>1.1.0-SNAPSHOT</solace.cloud.cloudfoundry.java-cfenv.version>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <repoName>SolaceProducts</repoName>
 
         <!-- This is the version of Spring Boot we have targeted for this build -->
-        <spring.boot.version>2.2.4.RELEASE</spring.boot.version>
-        <pivotal.cfenv.version>2.1.0.RELEASE</pivotal.cfenv.version>
+        <spring.boot.version>2.3.0.RELEASE</spring.boot.version>
+        <pivotal.cfenv.version>2.1.2.RELEASE</pivotal.cfenv.version>
 
         <solace.spring.boot.java-starter.version>4.0.1-SNAPSHOT</solace.spring.boot.java-starter.version>
         <solace.spring.boot.jms-starter.version>4.0.1-SNAPSHOT</solace.spring.boot.jms-starter.version>

--- a/solace-java-cfenv/README.md
+++ b/solace-java-cfenv/README.md
@@ -26,14 +26,14 @@ If, however, you want ONLY the `solace-java-cfenv` artifact, you can declare the
 <dependency>
     <groupId>com.solace.cloud.cloudfoundry</groupId>
     <artifactId>solace-java-cfenv</artifactId>
-    <version>1.0.0</version>    
+    <version>1.1.0</version>
 </dependency>
 ```
 
 ### Getting Started - Gradle
 ```groovy
 /* Solace Java CFEnv */
-compile("com.solace.cloud.cloudfoundry:solace-java-cfenv:1.0.0")
+compile("com.solace.cloud.cloudfoundry:solace-java-cfenv:1.1.0")
 ```
 
 ## Usage

--- a/solace-java-cfenv/pom.xml
+++ b/solace-java-cfenv/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
@@ -30,7 +30,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>solace-java-cfenv</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Solace Spring Java CFEnv</name>
 	<description>Java CFEnv for Solace services</description>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -28,11 +28,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-connectors-core</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-java-spring-boot-autoconfigure</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Autoconfiguration - Java</name>

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
@@ -42,12 +42,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-connectors-core</artifactId>
-			<optional>true</optional>
-		</dependency>
-
-		<dependency>
 			<groupId>com.solace.cloud.core</groupId>
 			<artifactId>solace-services-info</artifactId>
 			<version>${solace.services-info.version}</version>

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-jms-spring-boot-autoconfigure</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Autoconfiguration - JMS</name>

--- a/solace-spring-boot-bom/README.md
+++ b/solace-spring-boot-bom/README.md
@@ -17,6 +17,7 @@ Consult the table below to determine which version of the BOM you need to use:
 |Spring Boot       | Solace Spring Boot BOM |
 |----------------- |------------------------|
 | 2.2.4            | 1.0.0                  |
+| 2.3.0            | 1.1.0                  |
 
 ## Including the BOM
 
@@ -29,7 +30,7 @@ In addition to showing how to include the BOM, the following snippets also shows
         <dependency>
             <groupId>com.solace.spring.boot</groupId>
             <artifactId>solace-spring-boot-bom</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -57,7 +58,7 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "com.solace.spring.boot:solace-spring-boot-bom:1.0.0"
+        mavenBom "com.solace.spring.boot:solace-spring-boot-bom:1.1.0"
     }
 }
 
@@ -69,7 +70,7 @@ dependencies {
 ### Using it with Gradle 5
 ```groovy
 dependencies {
-    implementation(platform("com.solace.spring.boot:solace-spring-boot-bom:1.0.0"))
+    implementation(platform("com.solace.spring.boot:solace-spring-boot-bom:1.1.0"))
     implementation("com.solace.spring.boot:solace-spring-boot-starter")
 }
 ```

--- a/solace-spring-boot-bom/pom.xml
+++ b/solace-spring-boot-bom/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-spring-boot-build</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>solace-spring-boot-bom</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot BOM</name>

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-spring-boot-build</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>solace-spring-boot-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot Parent</name>
@@ -24,8 +24,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <solace.spring.boot.java-autoconf.version>4.0.1-SNAPSHOT</solace.spring.boot.java-autoconf.version>
-        <solace.spring.boot.jms-autoconf.version>4.0.1-SNAPSHOT</solace.spring.boot.jms-autoconf.version>
+        <solace.spring.boot.java-autoconf.version>4.1.0-SNAPSHOT</solace.spring.boot.java-autoconf.version>
+        <solace.spring.boot.jms-autoconf.version>4.1.0-SNAPSHOT</solace.spring.boot.jms-autoconf.version>
 
         <solace.jcsmp.version>10.8.1</solace.jcsmp.version>
         <solace.jms.version>10.8.1</solace.jms.version>

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -27,8 +27,8 @@
         <solace.spring.boot.java-autoconf.version>4.0.1-SNAPSHOT</solace.spring.boot.java-autoconf.version>
         <solace.spring.boot.jms-autoconf.version>4.0.1-SNAPSHOT</solace.spring.boot.jms-autoconf.version>
 
-        <solace.jcsmp.version>10.6.3</solace.jcsmp.version>
-        <solace.jms.version>10.6.3</solace.jms.version>
+        <solace.jcsmp.version>10.8.1</solace.jcsmp.version>
+        <solace.jms.version>10.8.1</solace.jms.version>
         <solace.services-info.version>0.4.0</solace.services-info.version>
     </properties>
 

--- a/solace-spring-boot-samples/pom.xml
+++ b/solace-spring-boot-samples/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.solace.spring.boot</groupId>
     <artifactId>solace-spring-boot-samples</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot Samples Parent</name>

--- a/solace-spring-boot-samples/solace-java-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-java-sample-app/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.2.4.RELEASE</spring.boot.version>
+		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
 		<solace.spring.boot.version>1.0.1-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 

--- a/solace-spring-boot-samples/solace-java-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-java-sample-app/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-samples</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>solace-java-sample-app</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Sample - Java</name>
@@ -21,7 +21,7 @@
 		<start-class>demo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
 		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
-		<solace.spring.boot.version>1.0.1-SNAPSHOT</solace.spring.boot.version>
+		<solace.spring.boot.version>1.1.0-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jndidemo.JndiDemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.2.4.RELEASE</spring.boot.version>
+		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
 		<solace.spring.boot.bom.version>1.0.1-SNAPSHOT</solace.spring.boot.bom.version>
 	</properties>
 

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-samples</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>solace-jms-sample-app-jndi</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Sample - JMS (JNDI)</name>
@@ -21,7 +21,7 @@
 		<start-class>jndidemo.JndiDemoApplication</start-class>
 		<java.version>1.8</java.version>
 		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
-		<solace.spring.boot.bom.version>1.0.1-SNAPSHOT</solace.spring.boot.bom.version>
+		<solace.spring.boot.bom.version>1.1.0-SNAPSHOT</solace.spring.boot.bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jmsdemo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.2.4.RELEASE</spring.boot.version>
+		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
 		<solace.spring.boot.version>1.0.1-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 

--- a/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-samples</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>solace-jms-sample-app</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Sample - JMS</name>
@@ -21,7 +21,7 @@
 		<start-class>jmsdemo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
 		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
-		<solace.spring.boot.version>1.0.1-SNAPSHOT</solace.spring.boot.version>
+		<solace.spring.boot.version>1.1.0-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>

--- a/solace-spring-boot-starters/solace-java-spring-boot-starter/README.md
+++ b/solace-spring-boot-starters/solace-java-spring-boot-starter/README.md
@@ -39,7 +39,7 @@ Note that you'll need to include version 3.1.0 or later to use Spring Boot relea
 
 ```groovy
 // Solace Java API & auto-configuration
-compile("com.solace.spring.boot:solace-java-spring-boot-starter:4.0.0")
+compile("com.solace.spring.boot:solace-java-spring-boot-starter:4.1.0")
 ```
 
 #### Using it with Maven
@@ -49,7 +49,7 @@ compile("com.solace.spring.boot:solace-java-spring-boot-starter:4.0.0")
 <dependency>
 	<groupId>com.solace.spring.boot</groupId>
 	<artifactId>solace-java-spring-boot-starter</artifactId>
-	<version>4.0.0</version>
+	<version>4.1.0</version>
 </dependency>
 ```
 

--- a/solace-spring-boot-starters/solace-java-spring-boot-starter/pom.xml
+++ b/solace-spring-boot-starters/solace-java-spring-boot-starter/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-java-spring-boot-starter</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Starter - Java</name>

--- a/solace-spring-boot-starters/solace-jms-spring-boot-starter/README.md
+++ b/solace-spring-boot-starters/solace-jms-spring-boot-starter/README.md
@@ -52,7 +52,7 @@ Note that you'll need to include version 3.1.0 or later to use Spring Boot relea
 #### Using it with Gradle
 
 ```groovy
-compile("com.solace.spring.boot:solace-jms-spring-boot-starter:4.0.0")
+compile("com.solace.spring.boot:solace-jms-spring-boot-starter:4.1.0")
 ```
 
 #### Using it with Maven
@@ -61,7 +61,7 @@ compile("com.solace.spring.boot:solace-jms-spring-boot-starter:4.0.0")
 <dependency>
 	<groupId>com.solace.spring.boot</groupId>
 	<artifactId>solace-jms-spring-boot-starter</artifactId>
-	<version>4.0.0</version>
+	<version>4.1.0</version>
 </dependency>
 ```
 

--- a/solace-spring-boot-starters/solace-jms-spring-boot-starter/pom.xml
+++ b/solace-spring-boot-starters/solace-jms-spring-boot-starter/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-jms-spring-boot-starter</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Starter - JMS</name>

--- a/solace-spring-boot-starters/solace-spring-boot-starter/pom.xml
+++ b/solace-spring-boot-starters/solace-spring-boot-starter/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-spring-boot-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>solace-spring-boot-starter</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Solace Spring Boot Starter</name>


### PR DESCRIPTION
* Upgraded Spring Boot to 2.3.0
* Upgraded Pivotal CF-Env to 2.1.2
* Upgraded Solace JCSMP and JMS to 10.8.1
* Removed spring-cloud-connectors-core from autoconfigs
* Prepare for 1.1.0 release