### PR TITLE
1.1.1 Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,23 @@
                 <artifactId>solace-java-cfenv</artifactId>
                 <version>${solace.cloud.cloudfoundry.java-cfenv.version}</version>
             </dependency>
+
+            <!-- Addressing log4j CVE-2021-44228 - Can be removed when we upgrade to spring-boot 2.6.2 -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.16.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/solace-java-cfenv/README.md
+++ b/solace-java-cfenv/README.md
@@ -26,14 +26,14 @@ If, however, you want ONLY the `solace-java-cfenv` artifact, you can declare the
 <dependency>
     <groupId>com.solace.cloud.cloudfoundry</groupId>
     <artifactId>solace-java-cfenv</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 </dependency>
 ```
 
 ### Getting Started - Gradle
 ```groovy
 /* Solace Java CFEnv */
-compile("com.solace.cloud.cloudfoundry:solace-java-cfenv:1.1.0")
+compile("com.solace.cloud.cloudfoundry:solace-java-cfenv:1.1.1")
 ```
 
 ## Usage

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaProperties.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaProperties.java
@@ -20,7 +20,6 @@
 package com.solace.spring.boot.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -98,7 +97,6 @@ public class SolaceJavaProperties {
      *
      * Example: solace.java.apiProperties.reapply_subscriptions=true
      */
-    @NestedConfigurationProperty
     private final Map<String,String> apiProperties = new ConcurrentHashMap<>();
 
 

--- a/solace-spring-boot-bom/README.md
+++ b/solace-spring-boot-bom/README.md
@@ -30,7 +30,7 @@ In addition to showing how to include the BOM, the following snippets also shows
         <dependency>
             <groupId>com.solace.spring.boot</groupId>
             <artifactId>solace-spring-boot-bom</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -58,7 +58,7 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "com.solace.spring.boot:solace-spring-boot-bom:1.1.0"
+        mavenBom "com.solace.spring.boot:solace-spring-boot-bom:1.1.1"
     }
 }
 
@@ -70,7 +70,7 @@ dependencies {
 ### Using it with Gradle 5
 ```groovy
 dependencies {
-    implementation(platform("com.solace.spring.boot:solace-spring-boot-bom:1.1.0"))
+    implementation(platform("com.solace.spring.boot:solace-spring-boot-bom:1.1.1"))
     implementation("com.solace.spring.boot:solace-spring-boot-starter")
 }
 ```

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -29,7 +29,7 @@
 
         <solace.jcsmp.version>10.8.1</solace.jcsmp.version>
         <solace.jms.version>10.8.1</solace.jms.version>
-        <solace.services-info.version>0.4.0</solace.services-info.version>
+        <solace.services-info.version>0.4.3</solace.services-info.version>
     </properties>
 
     <dependencyManagement>

--- a/solace-spring-boot-samples/pom.xml
+++ b/solace-spring-boot-samples/pom.xml
@@ -50,4 +50,25 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Addressing log4j CVE-2021-44228 - Can be removed when we upgrade to spring-boot 2.6.2 -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.16.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
# Global
* Upgrade `solace-services-info` to `0.4.3`
  * fixes CVE-2021-45046
* Force transitive usage of log4j `2.16.0` in projects and samples

# Solace Java Spring Boot Starter
* Fix `solace.java.api-properties` config metadata