### PR TITLE
1.2.0 Release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "com.solace.*"
+      - dependency-name: "com.solacesystems:*"
+      - dependency-name: "org.springframework.*"
+      - dependency-name: "io.pivotal.cfenv:*"
+      - dependency-name: "org.apache.logging.log4j:*"

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <repoName>SolaceProducts</repoName>
 
         <!-- This is the version of Spring Boot we have targeted for this build -->
-        <spring.boot.version>2.3.0.RELEASE</spring.boot.version>
-        <pivotal.cfenv.version>2.1.2.RELEASE</pivotal.cfenv.version>
+        <spring.boot.version>2.6.2</spring.boot.version>
+        <pivotal.cfenv.version>2.4.0</pivotal.cfenv.version>
 
         <solace.spring.boot.java-starter.version>4.1.2-SNAPSHOT</solace.spring.boot.java-starter.version>
         <solace.spring.boot.jms-starter.version>4.1.2-SNAPSHOT</solace.spring.boot.jms-starter.version>
@@ -92,23 +92,6 @@
                 <groupId>com.solace.cloud.cloudfoundry</groupId>
                 <artifactId>solace-java-cfenv</artifactId>
                 <version>${solace.cloud.cloudfoundry.java-cfenv.version}</version>
-            </dependency>
-
-            <!-- Addressing log4j CVE-2021-44228 - Can be removed when we upgrade to spring-boot 2.6.2 -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.16.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>2.16.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.16.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
             <distributionManagement>
                 <snapshotRepository>
                     <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
             </distributionManagement>
             <build>
@@ -132,7 +132,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <!--<stagingProfileId>1d86d96a0b6bce</stagingProfileId> -->
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <repoName>SolaceProducts</repoName>
 
         <!-- This is the version of Spring Boot we have targeted for this build -->
-        <spring.boot.version>2.6.2</spring.boot.version>
+        <spring.boot.version>2.6.4</spring.boot.version>
         <pivotal.cfenv.version>2.4.0</pivotal.cfenv.version>
 
         <solace.spring.boot.java-starter.version>4.2.0-SNAPSHOT</solace.spring.boot.java-starter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.solace.spring.boot</groupId>
     <artifactId>solace-spring-boot-build</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot Build</name>
@@ -18,10 +18,10 @@
         <spring.boot.version>2.6.2</spring.boot.version>
         <pivotal.cfenv.version>2.4.0</pivotal.cfenv.version>
 
-        <solace.spring.boot.java-starter.version>4.1.2-SNAPSHOT</solace.spring.boot.java-starter.version>
-        <solace.spring.boot.jms-starter.version>4.1.2-SNAPSHOT</solace.spring.boot.jms-starter.version>
-        <solace.spring.boot.starter.version>1.1.2-SNAPSHOT</solace.spring.boot.starter.version>
-        <solace.cloud.cloudfoundry.java-cfenv.version>1.1.2-SNAPSHOT</solace.cloud.cloudfoundry.java-cfenv.version>
+        <solace.spring.boot.java-starter.version>4.2.0-SNAPSHOT</solace.spring.boot.java-starter.version>
+        <solace.spring.boot.jms-starter.version>4.2.0-SNAPSHOT</solace.spring.boot.jms-starter.version>
+        <solace.spring.boot.starter.version>1.2.0-SNAPSHOT</solace.spring.boot.starter.version>
+        <solace.cloud.cloudfoundry.java-cfenv.version>1.2.0-SNAPSHOT</solace.cloud.cloudfoundry.java-cfenv.version>
     </properties>
 
     <licenses>

--- a/solace-java-cfenv/README.md
+++ b/solace-java-cfenv/README.md
@@ -26,14 +26,14 @@ If, however, you want ONLY the `solace-java-cfenv` artifact, you can declare the
 <dependency>
     <groupId>com.solace.cloud.cloudfoundry</groupId>
     <artifactId>solace-java-cfenv</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 
 ### Getting Started - Gradle
 ```groovy
 /* Solace Java CFEnv */
-compile("com.solace.cloud.cloudfoundry:solace-java-cfenv:1.1.1")
+compile("com.solace.cloud.cloudfoundry:solace-java-cfenv:1.2.0")
 ```
 
 ## Usage

--- a/solace-java-cfenv/pom.xml
+++ b/solace-java-cfenv/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
@@ -30,7 +30,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>solace-java-cfenv</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 
 	<name>Solace Spring Java CFEnv</name>
 	<description>Java CFEnv for Solace services</description>

--- a/solace-java-cfenv/pom.xml
+++ b/solace-java-cfenv/pom.xml
@@ -66,8 +66,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.5.2</version>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-java-spring-boot-autoconfigure</artifactId>
-	<version>4.1.2-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Autoconfiguration - Java</name>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTest.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTest.java
@@ -18,24 +18,22 @@
  */
 package com.solace.spring.boot.autoconfigure;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import com.solace.services.core.model.SolaceServiceCredentials;
-import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
-import org.junit.Test;
-
 import com.solacesystems.jcsmp.InvalidPropertiesException;
 import com.solacesystems.jcsmp.JCSMPChannelProperties;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.SpringJCSMPFactory;
-
+import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
+import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.BeanNotOfRequiredTypeException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SolaceJavaAutoConfigurationTest extends SolaceJavaAutoConfigurationTestBase {
@@ -131,11 +129,9 @@ public class SolaceJavaAutoConfigurationTest extends SolaceJavaAutoConfiguration
 		assertNotNull(this.context.getBean(SpringJCSMPFactoryCloudFactory.class));
 		assertNotNull(this.context.getBean(SpringJCSMPFactory.class));
 		assertNotNull(this.context.getBean(JCSMPProperties.class));
-                try {
-                    assertNull(this.context.getBean(SolaceServiceCredentials.class));
-                } catch (BeanNotOfRequiredTypeException e) {
-                    assert(e.getMessage().contains("was actually of type 'org.springframework.beans.factory.support.NullBean'"));
-                }
+		NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
+				this.context.getBean(SolaceServiceCredentials.class));
+		assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
 	}
 
 	@Test
@@ -144,11 +140,9 @@ public class SolaceJavaAutoConfigurationTest extends SolaceJavaAutoConfiguration
 		assertNotNull(this.context.getBean(SpringJCSMPFactoryCloudFactory.class));
 		assertNotNull(this.context.getBean(SpringJCSMPFactory.class));
 		assertNotNull(this.context.getBean(JCSMPProperties.class));
-                try {
-                    assertNull(this.context.getBean(SolaceServiceCredentials.class));
-                } catch (BeanNotOfRequiredTypeException e) {
-                    assert(e.getMessage().contains("was actually of type 'org.springframework.beans.factory.support.NullBean'"));
-                }
+		NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
+				this.context.getBean(SolaceServiceCredentials.class));
+		assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
 	}
 
 }

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-jms-spring-boot-autoconfigure</artifactId>
-	<version>4.1.2-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Autoconfiguration - JMS</name>

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationTest.java
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationTest.java
@@ -23,13 +23,13 @@ import com.solacesystems.jms.SolConnectionFactory;
 import com.solacesystems.jms.SolConnectionFactoryImpl;
 import com.solacesystems.jms.SpringSolJmsConnectionFactoryCloudFactory;
 import org.junit.Test;
-import org.springframework.beans.factory.BeanNotOfRequiredTypeException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.jms.core.JmsTemplate;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class SolaceJmsAutoConfigurationTest extends SolaceJmsAutoConfigurationTestBase {
@@ -97,10 +97,8 @@ public class SolaceJmsAutoConfigurationTest extends SolaceJmsAutoConfigurationTe
 
 		assertNotNull(this.context.getBean(SolConnectionFactory.class));
 		assertNotNull(this.context.getBean(SpringSolJmsConnectionFactoryCloudFactory.class));
-		try {
-			assertNull(this.context.getBean(SolaceServiceCredentials.class));
-		} catch (BeanNotOfRequiredTypeException e) {
-			assert(e.getMessage().contains("was actually of type 'org.springframework.beans.factory.support.NullBean'"));
-		}
+		NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
+				this.context.getBean(SolaceServiceCredentials.class));
+		assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
 	}
 }

--- a/solace-spring-boot-bom/README.md
+++ b/solace-spring-boot-bom/README.md
@@ -18,6 +18,7 @@ Consult the table below to determine which version of the BOM you need to use:
 |----------------- |------------------------|
 | 2.2.4            | 1.0.0                  |
 | 2.3.0            | 1.1.0                  |
+| 2.6.2            | 1.2.0                  |
 
 ## Including the BOM
 
@@ -30,7 +31,7 @@ In addition to showing how to include the BOM, the following snippets also shows
         <dependency>
             <groupId>com.solace.spring.boot</groupId>
             <artifactId>solace-spring-boot-bom</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -58,7 +59,7 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "com.solace.spring.boot:solace-spring-boot-bom:1.1.1"
+        mavenBom "com.solace.spring.boot:solace-spring-boot-bom:1.2.0"
     }
 }
 
@@ -70,7 +71,7 @@ dependencies {
 ### Using it with Gradle 5
 ```groovy
 dependencies {
-    implementation(platform("com.solace.spring.boot:solace-spring-boot-bom:1.1.1"))
+    implementation(platform("com.solace.spring.boot:solace-spring-boot-bom:1.2.0"))
     implementation("com.solace.spring.boot:solace-spring-boot-starter")
 }
 ```

--- a/solace-spring-boot-bom/README.md
+++ b/solace-spring-boot-bom/README.md
@@ -18,7 +18,7 @@ Consult the table below to determine which version of the BOM you need to use:
 |----------------- |------------------------|
 | 2.2.4            | 1.0.0                  |
 | 2.3.0            | 1.1.0                  |
-| 2.6.2            | 1.2.0                  |
+| 2.6.4            | 1.2.0                  |
 
 ## Including the BOM
 

--- a/solace-spring-boot-bom/pom.xml
+++ b/solace-spring-boot-bom/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-spring-boot-build</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>solace-spring-boot-bom</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot BOM</name>

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -34,6 +34,18 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+			Workaround for CVE-2021-45046
+			Remove after upgrading to Spring Boot >= 2.6.3
+			 -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.17.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <!-- Import Spring Boot dependency management -->
                 <groupId>org.springframework.boot</groupId>

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -27,8 +27,8 @@
         <solace.spring.boot.java-autoconf.version>4.2.0-SNAPSHOT</solace.spring.boot.java-autoconf.version>
         <solace.spring.boot.jms-autoconf.version>4.2.0-SNAPSHOT</solace.spring.boot.jms-autoconf.version>
 
-        <solace.jcsmp.version>10.8.1</solace.jcsmp.version>
-        <solace.jms.version>10.8.1</solace.jms.version>
+        <solace.jcsmp.version>10.13.1</solace.jcsmp.version>
+        <solace.jms.version>10.13.1</solace.jms.version>
         <solace.services-info.version>0.4.3</solace.services-info.version>
     </properties>
 
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.17.1</version>
+                <version>2.17.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-spring-boot-build</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>solace-spring-boot-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot Parent</name>
@@ -24,8 +24,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <solace.spring.boot.java-autoconf.version>4.1.2-SNAPSHOT</solace.spring.boot.java-autoconf.version>
-        <solace.spring.boot.jms-autoconf.version>4.1.2-SNAPSHOT</solace.spring.boot.jms-autoconf.version>
+        <solace.spring.boot.java-autoconf.version>4.2.0-SNAPSHOT</solace.spring.boot.java-autoconf.version>
+        <solace.spring.boot.jms-autoconf.version>4.2.0-SNAPSHOT</solace.spring.boot.jms-autoconf.version>
 
         <solace.jcsmp.version>10.8.1</solace.jcsmp.version>
         <solace.jms.version>10.8.1</solace.jms.version>

--- a/solace-spring-boot-samples/pom.xml
+++ b/solace-spring-boot-samples/pom.xml
@@ -50,25 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Addressing log4j CVE-2021-44228 - Can be removed when we upgrade to spring-boot 2.6.2 -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.16.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>2.16.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.16.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/solace-spring-boot-samples/pom.xml
+++ b/solace-spring-boot-samples/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.solace.spring.boot</groupId>
     <artifactId>solace-spring-boot-samples</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Solace Spring Boot Samples Parent</name>

--- a/solace-spring-boot-samples/solace-java-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-java-sample-app/pom.xml
@@ -20,12 +20,24 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
+		<spring.boot.version>2.6.2</spring.boot.version>
 		<solace.spring.boot.version>1.1.2-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+			<!--
+			Workaround for CVE-2021-45046
+			Remove after upgrading to Spring Boot >= 2.6.3
+			 -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>2.17.1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>

--- a/solace-spring-boot-samples/solace-java-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-java-sample-app/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-samples</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>solace-java-sample-app</artifactId>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Sample - Java</name>
@@ -21,7 +21,7 @@
 		<start-class>demo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
 		<spring.boot.version>2.6.2</spring.boot.version>
-		<solace.spring.boot.version>1.1.2-SNAPSHOT</solace.spring.boot.version>
+		<solace.spring.boot.version>1.2.0-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>

--- a/solace-spring-boot-samples/solace-java-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-java-sample-app/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.6.2</spring.boot.version>
+		<spring.boot.version>2.6.4</spring.boot.version>
 		<solace.spring.boot.version>1.2.0-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 

--- a/solace-spring-boot-samples/solace-java-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-java-sample-app/pom.xml
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-bom</artifactId>
-				<version>2.17.1</version>
+				<version>2.17.2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jndidemo.JndiDemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.6.2</spring.boot.version>
+		<spring.boot.version>2.6.4</spring.boot.version>
 		<solace.spring.boot.bom.version>1.2.0-SNAPSHOT</solace.spring.boot.bom.version>
 	</properties>
 

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-samples</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>solace-jms-sample-app-jndi</artifactId>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Sample - JMS (JNDI)</name>
@@ -21,7 +21,7 @@
 		<start-class>jndidemo.JndiDemoApplication</start-class>
 		<java.version>1.8</java.version>
 		<spring.boot.version>2.6.2</spring.boot.version>
-		<solace.spring.boot.bom.version>1.1.2-SNAPSHOT</solace.spring.boot.bom.version>
+		<solace.spring.boot.bom.version>1.2.0-SNAPSHOT</solace.spring.boot.bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
@@ -20,12 +20,24 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jndidemo.JndiDemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
+		<spring.boot.version>2.6.2</spring.boot.version>
 		<solace.spring.boot.bom.version>1.1.2-SNAPSHOT</solace.spring.boot.bom.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+			<!--
+			Workaround for CVE-2021-45046
+			Remove after upgrading to Spring Boot >= 2.6.3
+			 -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>2.17.1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-bom</artifactId>
-				<version>2.17.1</version>
+				<version>2.17.2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
@@ -20,12 +20,24 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jmsdemo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.3.0.RELEASE</spring.boot.version>
+		<spring.boot.version>2.6.2</spring.boot.version>
 		<solace.spring.boot.version>1.1.2-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+			<!--
+			Workaround for CVE-2021-45046
+			Remove after upgrading to Spring Boot >= 2.6.3
+			 -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>2.17.1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>

--- a/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jmsdemo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
-		<spring.boot.version>2.6.2</spring.boot.version>
+		<spring.boot.version>2.6.4</spring.boot.version>
 		<solace.spring.boot.version>1.2.0-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 

--- a/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-samples</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>solace-jms-sample-app</artifactId>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Sample - JMS</name>
@@ -21,7 +21,7 @@
 		<start-class>jmsdemo.DemoApplication</start-class>
 		<java.version>1.8</java.version>
 		<spring.boot.version>2.6.2</spring.boot.version>
-		<solace.spring.boot.version>1.1.2-SNAPSHOT</solace.spring.boot.version>
+		<solace.spring.boot.version>1.2.0-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>

--- a/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-bom</artifactId>
-				<version>2.17.1</version>
+				<version>2.17.2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/solace-spring-boot-starters/solace-java-spring-boot-starter/README.md
+++ b/solace-spring-boot-starters/solace-java-spring-boot-starter/README.md
@@ -129,6 +129,7 @@ Any additional Solace Java API properties can be set through configuring `solace
 ```
 solace.java.apiProperties.reapply_subscriptions=false
 solace.java.apiProperties.ssl_trust_store=/path/to/truststore
+solace.java.apiProperties.client_channel_properties.keepAliveIntervalInMillis=3000
 ```
 
 Note that the direct configuration of `solace.java.` properties takes precedence over the `solace.java.apiProperties.`.

--- a/solace-spring-boot-starters/solace-java-spring-boot-starter/pom.xml
+++ b/solace-spring-boot-starters/solace-java-spring-boot-starter/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-java-spring-boot-starter</artifactId>
-	<version>4.1.2-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Starter - Java</name>

--- a/solace-spring-boot-starters/solace-jms-spring-boot-starter/pom.xml
+++ b/solace-spring-boot-starters/solace-jms-spring-boot-starter/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>com.solace.spring.boot</groupId>
 		<artifactId>solace-spring-boot-parent</artifactId>
-		<version>1.1.2-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>solace-jms-spring-boot-starter</artifactId>
-	<version>4.1.2-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Solace Spring Boot Starter - JMS</name>

--- a/solace-spring-boot-starters/solace-spring-boot-starter/pom.xml
+++ b/solace-spring-boot-starters/solace-spring-boot-starter/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.solace.spring.boot</groupId>
         <artifactId>solace-spring-boot-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../../solace-spring-boot-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>solace-spring-boot-starter</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Solace Spring Boot Starter</name>


### PR DESCRIPTION
# Global
* Upgrade Spring Boot to `2.6.4`
* Upgrade Solace JCSMP to `10.13.1`
* Upgrade Solace JMS to `10.13.1`
* Upgrade Log4j to `2.17.2` (applies only to build & tests)
* Update Sonatype URLs to use the s01 server
* Add Dependabot
  * closes #5 

# Solace Java CFEnv
* Upgrade Java CFEnv to `2.4.0`