### PR TITLE
increase dependabot open-pull-requests-limit to 50

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 50
     allow:
       - dependency-name: "com.solace.*"
       - dependency-name: "com.solacesystems:*"


### PR DESCRIPTION
Fix Dependabot getting blocked by 5 PR limit.