### PR TITLE
Spring Boot 3 and Java 17 support (waiting for JMS 2.0 support on sol-jms)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JDK 1.8
+      - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
       - name: Build and run Tests
         run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <repoName>SolaceProducts</repoName>
 
         <!-- This is the version of Spring Boot we have targeted for this build -->
-        <spring.boot.version>2.6.6</spring.boot.version>
-        <pivotal.cfenv.version>2.4.0</pivotal.cfenv.version>
+        <spring.boot.version>3.0.1</spring.boot.version>
+        <pivotal.cfenv.version>2.4.1</pivotal.cfenv.version>
 
         <solace.spring.boot.java-starter.version>4.2.3-SNAPSHOT</solace.spring.boot.java-starter.version>
         <solace.spring.boot.jms-starter.version>4.2.3-SNAPSHOT</solace.spring.boot.jms-starter.version>
@@ -120,7 +120,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.8.2</version>
+                        <version>3.0.0</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -128,7 +128,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -140,7 +140,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -334,13 +334,13 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.3.0</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.14.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -349,7 +349,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <tagNameFormat>@{project.version}</tagNameFormat>
                 </configuration>
@@ -357,16 +357,20 @@
                     <dependency>
                         <groupId>org.apache.maven.shared</groupId>
                         <artifactId>maven-invoker</artifactId>
-                        <version>2.2</version>
+                        <version>3.2.0</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
@@ -378,7 +382,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -391,7 +395,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -404,7 +408,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.3.0</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>oss</flattenMode>

--- a/solace-java-cfenv/pom.xml
+++ b/solace-java-cfenv/pom.xml
@@ -67,18 +67,19 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
+			<version>2.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.8.2</version>
+			<version>5.9.0</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- Environment variable stubs -->
 		<dependency>
-			<groupId>com.github.stefanbirkner</groupId>
-			<artifactId>system-rules</artifactId>
-			<version>1.19.0</version>
+			<groupId>uk.org.webcompere</groupId>
+			<artifactId>system-stubs-jupiter</artifactId>
+			<version>2.0.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/solace-java-cfenv/src/main/java/com/solace/spring/cloud/core/SolaceServiceCredentialsFactory.java
+++ b/solace-java-cfenv/src/main/java/com/solace/spring/cloud/core/SolaceServiceCredentialsFactory.java
@@ -80,73 +80,29 @@ public class SolaceServiceCredentialsFactory {
 		for (Map.Entry<String, Object> entry : service.getCredentials().getMap().entrySet()) {
 			String key = entry.getKey();
 			Object value = entry.getValue();
-
 			switch (key) {
-				case "clientUsername":
-					credentials.setClientUsername((String) value);
-					break;
-				case "clientPassword":
-					credentials.setClientPassword((String) value);
-					break;
-				case "msgVpnName":
-					credentials.setMsgVpnName((String) value);
-					break;
-				case "smfHosts":
-					credentials.setSmfHosts((List<String>) value);
-					break;
-				case "smfTlsHosts":
-					credentials.setSmfTlsHosts((List<String>) value);
-					break;
-				case "smfZipHosts":
-					credentials.setSmfZipHosts((List<String>) value);
-					break;
-				case "jmsJndiUris":
-					credentials.setJmsJndiUris((List<String>) value);
-					break;
-				case "jmsJndiTlsUris":
-					credentials.setJmsJndiTlsUris((List<String>) value);
-					break;
-				case "managementUsername":
-					credentials.setManagementUsername((String) value);
-					break;
-				case "managementPassword":
-					credentials.setManagementPassword((String) value);
-					break;
-				case "activeManagementHostname":
-					credentials.setActiveManagementHostname((String) value);
-					break;
-				case "restUris":
-					credentials.setRestUris((List<String>) value);
-					break;
-				case "restTlsUris":
-					credentials.setRestTlsUris((List<String>) value);
-					break;
-				case "mqttUris":
-					credentials.setMqttUris((List<String>) value);
-					break;
-				case "mqttTlsUris":
-					credentials.setMqttTlsUris((List<String>) value);
-					break;
-				case "mqttWsUris":
-					credentials.setMqttWsUris((List<String>) value);
-					break;
-				case "mqttWssUris":
-					credentials.setMqttWssUris((List<String>) value);
-					break;
-				case "amqpUris":
-					credentials.setAmqpUris((List<String>) value);
-					break;
-				case "amqpTlsUris":
-					credentials.setAmqpTlsUris((List<String>) value);
-					break;
-				case "managementHostnames":
-					credentials.setManagementHostnames((List<String>) value);
-					break;
-				case "dmrClusterName":
-					credentials.setDmrClusterName((String) value);
-					break;
-				case "dmrClusterPassword":
-					credentials.setDmrClusterPassword((String) value);
+				case "clientUsername" -> credentials.setClientUsername((String) value);
+				case "clientPassword" -> credentials.setClientPassword((String) value);
+				case "msgVpnName" -> credentials.setMsgVpnName((String) value);
+				case "smfHosts" -> credentials.setSmfHosts((List<String>) value);
+				case "smfTlsHosts" -> credentials.setSmfTlsHosts((List<String>) value);
+				case "smfZipHosts" -> credentials.setSmfZipHosts((List<String>) value);
+				case "jmsJndiUris" -> credentials.setJmsJndiUris((List<String>) value);
+				case "jmsJndiTlsUris" -> credentials.setJmsJndiTlsUris((List<String>) value);
+				case "managementUsername" -> credentials.setManagementUsername((String) value);
+				case "managementPassword" -> credentials.setManagementPassword((String) value);
+				case "activeManagementHostname" -> credentials.setActiveManagementHostname((String) value);
+				case "restUris" -> credentials.setRestUris((List<String>) value);
+				case "restTlsUris" -> credentials.setRestTlsUris((List<String>) value);
+				case "mqttUris" -> credentials.setMqttUris((List<String>) value);
+				case "mqttTlsUris" -> credentials.setMqttTlsUris((List<String>) value);
+				case "mqttWsUris" -> credentials.setMqttWsUris((List<String>) value);
+				case "mqttWssUris" -> credentials.setMqttWssUris((List<String>) value);
+				case "amqpUris" -> credentials.setAmqpUris((List<String>) value);
+				case "amqpTlsUris" -> credentials.setAmqpTlsUris((List<String>) value);
+				case "managementHostnames" -> credentials.setManagementHostnames((List<String>) value);
+				case "dmrClusterName" -> credentials.setDmrClusterName((String) value);
+				case "dmrClusterPassword" -> credentials.setDmrClusterPassword((String) value);
 			}
 		}
 

--- a/solace-java-cfenv/src/test/java/com.solace.spring.cloud/cloudfoundry/SolaceServiceCredentialsFactoryTest.java
+++ b/solace-java-cfenv/src/test/java/com.solace.spring.cloud/cloudfoundry/SolaceServiceCredentialsFactoryTest.java
@@ -19,372 +19,364 @@
 
 package com.solace.spring.cloud.cloudfoundry;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-
-import java.util.*;
-
 import com.google.gson.Gson;
 import com.solace.services.core.model.SolaceServiceCredentials;
-import org.junit.Rule;
-import org.junit.Test;
-
 import com.solace.spring.cloud.core.SolaceServiceCredentialsFactory;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-public class SolaceServiceCredentialsFactoryTest {
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-	private static final String PUBSUB_LABEL = "solace-pubsub";
-	private static final String PUBSUB_TAG = "solace-pubsub";
+@ExtendWith(SystemStubsExtension.class)
+class SolaceServiceCredentialsFactoryTest {
 
-	private static final String USER_PROVIDED_LABEL = "user-provided";
-	private static final String USER_PROVIDED_NAME = "user-provided";
+    @SystemStub
+    private EnvironmentVariables environmentVariables;
 
-	@BeforeEach
-    public void cleanEnvironment() {
-        environmentVariables.clear("VCAP_SERVICES");
+    private static final String VCAP_SVC_ENV = "VCAP_SERVICES";
+    private static final String PUBSUB_LABEL = "solace-pubsub";
+    private static final String PUBSUB_TAG = "solace-pubsub";
+
+    private static final String USER_PROVIDED_LABEL = "user-provided";
+    private static final String USER_PROVIDED_NAME = "user-provided";
+
+    @Test
+    void testNoServices() {
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(0, solaceServiceCredentialsList.size());
     }
 
     @Test
-	public void testNoServices() {
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(0, solaceServiceCredentialsList.size());
-	}
+    void testSinglePubsubServiceWithLabelAndTag() {
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-	@Test
-	public void testSinglePubsubServiceWithLabelAndTag() {
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, tags));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(1, solaceServiceCredentialsList.size());
-		validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
-	}
-
-	@Test
-	public void testSinglePubsubServiceWithLabelOnly() {
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, null));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(1, solaceServiceCredentialsList.size());
-		validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
-	}
-
-	@Test
-	public void testSinglePubsubServiceWithTagOnly() {
-
-		// This label won't be used for solace pubsub service discovery
-		// The specified tag 'solace-pubsub' will be used instead
-		String label = "i-am-still-a-solace-pubsub-service";
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", label, tags));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(1, solaceServiceCredentialsList.size());
-		validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
-	}
-
-	@Test
-	public void testMultiplePubsubServicesWithLabelAndTag() {
-		String label = PUBSUB_LABEL;
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-1", label, tags));
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-2", label, tags));
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-3", label, tags));
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-4", label, tags));
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-5", label, tags));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(5, solaceServiceCredentialsList.size());
-		for (SolaceServiceCredentials solaceServiceCredentials : solaceServiceCredentialsList) {
-			validateSolaceServiceCredentials(solaceServiceCredentials);
-		}
-	}
-
-	@Test
-	public void testMultiplePubsubServicesWithMixedLabelsAndTags() {
-		String label = PUBSUB_LABEL;
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// This label won't be used for solace pubsub service discovery
-		// The specified tag 'solace-pubsub' will be used instead
-		String alternateLabel = "i-am-still-a-solace-pubsub-service";
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-1", label, tags));
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-2", alternateLabel, tags));
-		pubsubServices.add(createSolacePubsubVcapService(USER_PROVIDED_NAME, USER_PROVIDED_LABEL, tags));
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-4", alternateLabel, tags));
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-5", label, null));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(5, solaceServiceCredentialsList.size());
-		for (SolaceServiceCredentials solaceServiceCredentials : solaceServiceCredentialsList) {
-			validateSolaceServiceCredentials(solaceServiceCredentials);
-		}
-	}
-
-	@Test
-	public void testOnlyThirdPartyServices() {
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createThirdPartyVcapService("rabbit-mq-1", "rabbit-mq", Arrays.asList("pivotal", "rabbit-mq")));
-		pubsubServices.add(createThirdPartyVcapService("MySQL DB", "MySQL", Arrays.asList("sql", "mysql", "database", "relational")));
-		pubsubServices.add(createThirdPartyVcapService("Kakfa instance", "Kafka", Arrays.asList("apache", "kafka")));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(0, solaceServiceCredentialsList.size());
-	}
-
-	@Test
-	public void testSinglePubsubServiceWithThirdPartyServices() {
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-1", PUBSUB_LABEL, tags));
-		pubsubServices.add(createThirdPartyVcapService("rabbit-mq-1", "rabbit-mq", Arrays.asList("pivotal", "rabbit-mq")));
-		pubsubServices.add(createThirdPartyVcapService("MySQL DB", "MySQL", Arrays.asList("sql", "mysql", "database", "relational")));
-		pubsubServices.add(createThirdPartyVcapService("Kakfa instance", "Kafka", Arrays.asList("apache", "kafka")));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(1, solaceServiceCredentialsList.size());
-		validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
-	}
-
-	// We could do a lot more negative testing. But other Spring cloud
-	// connectors seem very tolerant. For now starting with this limited
-	// coverage.
-	@Test
-	public void testSinglePubsubServiceWithMissingCredentials() {
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, tags));
-		pubsubServices.get(0).remove("credentials");
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Should still be accepted
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(1, solaceServiceCredentialsList.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testSinglePubsubServiceWithCorruptedCredentials() {
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, tags));
-		((Map<String,Object>) pubsubServices.get(0).get("credentials")).remove("smfHosts");
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Should still be accepted
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(1, solaceServiceCredentialsList.size());
-
-		// Validate smf is null, while other credentials exist
-		SolaceServiceCredentials credentials = solaceServiceCredentialsList.get(0);
-		assertNull(credentials.getSmfHost());
-		assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", credentials.getSmfTlsHost());
-	}
-
-	@Test
-	public void testSingleUserProvidedPubsubService() {
-		List<String> tags = Collections.singletonList(PUBSUB_TAG);
-
-		// Create services
-		List<Map<String, Object>> pubsubServices = new ArrayList<>();
-		pubsubServices.add(createSolacePubsubVcapService(USER_PROVIDED_NAME, USER_PROVIDED_LABEL, tags));
-		setVcapServices(createVcapServiceList(pubsubServices));
-
-		// Validate services credentials were loaded correctly
-		List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		assertEquals(1, solaceServiceCredentialsList.size());
-		validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
-	}
-
-    private void setVcapServices(Map<String, List<Object>> vcapServicesData) {
-        Gson gson = new Gson();
-        String vcapServicesJson = gson.toJson(vcapServicesData);
-        System.out.println("VCAP_SERVICES = " + vcapServicesJson);
-        environmentVariables.set("VCAP_SERVICES", vcapServicesJson);
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, tags));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(1, solaceServiceCredentialsList.size());
+        validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
     }
 
-	/**
-	 * @return a representation of the solace service credentials of a solace VCAP service
-	 */
-	private Map<String,Object> createServiceCredentials() {
+    @Test
+    void testSinglePubsubServiceWithLabelOnly() {
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, null));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(1, solaceServiceCredentialsList.size());
+        validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
+    }
 
-		Map<String, Object> credentials = new HashMap<>();
+    @Test
+    void testSinglePubsubServiceWithTagOnly() {
 
-		credentials.put("clientUsername", "sample-client-username");
-		credentials.put("clientPassword", "sample-client-password");
-		credentials.put("msgVpnName", "sample-msg-vpn");
-		credentials.put("smfHosts", Collections.singletonList("tcp://192.168.1.50:7000"));
-		credentials.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.50:7003", "tcps://192.168.1.51:7003"));
-		credentials.put("smfZipHosts", Collections.singletonList("tcp://192.168.1.50:7001"));
-		credentials.put("webMessagingUris", Collections.singletonList("http://192.168.1.50:80"));
-		credentials.put("webMessagingTlsUris", Collections.singletonList("https://192.168.1.50:80"));
-		credentials.put("jmsJndiUris", Collections.singletonList("smf://192.168.1.50:7000"));
-		credentials.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.50:7003", "smfs://192.168.1.51:7003"));
-		credentials.put("mqttUris", Collections.singletonList("tcp://192.168.1.50:7020"));
-		credentials.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021"));
-		credentials.put("mqttWsUris", Collections.singletonList("ws://192.168.1.50:7022"));
-		credentials.put("mqttWssUris", Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023"));
-		credentials.put("restUris", Collections.singletonList("http://192.168.1.50:7018"));
-		credentials.put("restTlsUris", Collections.singletonList("https://192.168.1.50:7019"));
-		credentials.put("amqpUris", Collections.singletonList("amqp://192.168.1.50:7016"));
-		credentials.put("amqpTlsUris", Collections.singletonList("amqps://192.168.1.50:7017"));
-		credentials.put("managementHostnames", Collections.singletonList("vmr-Medium-VMR-0"));
-		credentials.put("managementUsername", "sample-mgmt-username");
-		credentials.put("managementPassword", "sample-mgmt-password");
-		credentials.put("activeManagementHostname", "vmr-medium-web");
-		credentials.put("dmrClusterName", "dmr-cluster-name");
-		credentials.put("dmrClusterPassword", "dmr-cluster-password");
+        // This label won't be used for solace pubsub service discovery
+        // The specified tag 'solace-pubsub' will be used instead
+        String label = "i-am-still-a-solace-pubsub-service";
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-		return credentials;
-	}
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", label, tags));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(1, solaceServiceCredentialsList.size());
+        validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
+    }
 
-	/**
-	 * @return a map representation of a single VCAP service listing
-	 * i.e.:
-	 * {
-	 *     "binding_name": null,
-	 *     "credentials": { (credentials) },
-	 *     "instance_name": "cool-pubsub-service",
-	 *     "label": "solace-pubsub",
-	 *     "name": "cool-pubsub-service",
-	 *     "plan": "standard-plan-3",
-	 *     "tags": [ (tags) ],
-	 * }
-	 */
-	private Map<String, Object> createSolacePubsubVcapService(String name, String label, List<String> tags) {
-		Map<String, Object> vcapService = new HashMap<>();
-		vcapService.put("credentials", createServiceCredentials());
-		vcapService.put("label", label);
-		vcapService.put("name", name);
-		vcapService.put("plan", "vmr-shared");
-		vcapService.put("provider", "Solace Systems");
-		vcapService.put("tags", tags);
+    @Test
+    void testMultiplePubsubServicesWithLabelAndTag() {
+        String label = PUBSUB_LABEL;
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-		return vcapService;
-	}
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-1", label, tags));
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-2", label, tags));
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-3", label, tags));
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-4", label, tags));
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-5", label, tags));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(5, solaceServiceCredentialsList.size());
+        for (SolaceServiceCredentials solaceServiceCredentials : solaceServiceCredentialsList) {
+            validateSolaceServiceCredentials(solaceServiceCredentials);
+        }
+    }
 
-	private Map<String, Object> createThirdPartyVcapService(String name, String label, List<String> tags) {
-		Map<String, Object> vcapService = new HashMap<>();
-		vcapService.put("credentials", null);
-		vcapService.put("label", label);
-		vcapService.put("name", name);
-		vcapService.put("plan", "dummy-plan");
-		vcapService.put("provider", "Company Name");
-		vcapService.put("tags", tags);
+    @Test
+    void testMultiplePubsubServicesWithMixedLabelsAndTags() {
+        String label = PUBSUB_LABEL;
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-		return vcapService;
-	}
+        // This label won't be used for solace pubsub service discovery
+        // The specified tag 'solace-pubsub' will be used instead
+        String alternateLabel = "i-am-still-a-solace-pubsub-service";
 
-	/**
-	 * @return a map representation of the VCAP service listings
-	 * This is what would be found at the root of the VCAP_SERVICES environment variable
-	 * i.e.:
-	 * "solace-pubsub": [
-	 *    { (service listing) },
-	 *    { (service listing) }
-	 *  ],
-	 * "user-provided": [
-	 *    { (service listing) }
-	 *  ]
-	 */
-	private Map<String,List<Object>> createVcapServiceList(List<Map<String, Object>> vcapServices) {
-		Map<String, List<Object>> vcapServiceList = new HashMap<>();
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-1", label, tags));
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-2", alternateLabel, tags));
+        pubsubServices.add(createSolacePubsubVcapService(USER_PROVIDED_NAME, USER_PROVIDED_LABEL, tags));
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-4", alternateLabel, tags));
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-5", label, null));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(5, solaceServiceCredentialsList.size());
+        for (SolaceServiceCredentials solaceServiceCredentials : solaceServiceCredentialsList) {
+            validateSolaceServiceCredentials(solaceServiceCredentials);
+        }
+    }
 
-		// Add services to VCAP service list by label
-		for (Map<String,Object> service : vcapServices) {
-			String label = (String) service.get("label");
+    @Test
+    void testOnlyThirdPartyServices() {
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createThirdPartyVcapService("rabbit-mq-1", "rabbit-mq", asList("pivotal", "rabbit-mq")));
+        pubsubServices.add(createThirdPartyVcapService("MySQL DB", "MySQL", asList("sql", "mysql", "database", "relational")));
+        pubsubServices.add(createThirdPartyVcapService("Kakfa instance", "Kafka", asList("apache", "kafka")));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(0, solaceServiceCredentialsList.size());
+    }
 
-			if (label != null) {
-				if (vcapServiceList.get(label) == null) {
-					vcapServiceList.computeIfAbsent(label, value -> new ArrayList<>());
-					vcapServiceList.put(label, new ArrayList<>());
-				}
-				vcapServiceList.get(label).add(service);
-			}
-		}
+    @Test
+    void testSinglePubsubServiceWithThirdPartyServices() {
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-		return vcapServiceList;
-	}
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("solace-pubsub-1", PUBSUB_LABEL, tags));
+        pubsubServices.add(createThirdPartyVcapService("rabbit-mq-1", "rabbit-mq", asList("pivotal", "rabbit-mq")));
+        pubsubServices.add(createThirdPartyVcapService("MySQL DB", "MySQL", asList("sql", "mysql", "database", "relational")));
+        pubsubServices.add(createThirdPartyVcapService("Kakfa instance", "Kafka", asList("apache", "kafka")));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(1, solaceServiceCredentialsList.size());
+        validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
+    }
 
-	private void validateSolaceServiceCredentials(SolaceServiceCredentials credentials) {
-		// Validate it all got set correctly.
+    // We could do a lot more negative testing. But other Spring cloud
+    // connectors seem very tolerant. For now starting with this limited
+    // coverage.
+    @Test
+    void testSinglePubsubServiceWithMissingCredentials() {
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-		// Check Top Level stuff
-		assertEquals("sample-client-username", credentials.getClientUsername());
-		assertEquals("sample-client-password", credentials.getClientPassword());
-		assertEquals("sample-msg-vpn", credentials.getMsgVpnName());
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, tags));
+        pubsubServices.get(0).remove("credentials");
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Should still be accepted
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(1, solaceServiceCredentialsList.size());
+    }
 
-		// Check SMF
-		assertEquals("tcp://192.168.1.50:7000", credentials.getSmfHost());
-		assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", credentials.getSmfTlsHost());
-		assertEquals("tcp://192.168.1.50:7001", credentials.getSmfZipHost());
+    @Test
+    @SuppressWarnings("unchecked")
+    void testSinglePubsubServiceWithCorruptedCredentials() {
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-		// Check JMS
-		assertEquals("smf://192.168.1.50:7000", credentials.getJmsJndiUri());
-		assertEquals("smfs://192.168.1.50:7003,smfs://192.168.1.51:7003", credentials.getJmsJndiTlsUri());
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService("test-solace-pubsub", PUBSUB_LABEL, tags));
+        ((Map<String, Object>) pubsubServices.get(0).get("credentials")).remove("smfHosts");
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Should still be accepted
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(1, solaceServiceCredentialsList.size());
 
-		// Check MQTT
-		assertThat(credentials.getMqttUris(), is(Collections.singletonList("tcp://192.168.1.50:7020")));
-		assertThat(credentials.getMqttTlsUris(), is(Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021")));
-		assertThat(credentials.getMqttWsUris(), is(Collections.singletonList("ws://192.168.1.50:7022")));
-		assertThat(credentials.getMqttWssUris(), is(Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023")));
+        // Validate smf is null, while other credentials exist
+        SolaceServiceCredentials credentials = solaceServiceCredentialsList.get(0);
+        assertNull(credentials.getSmfHost());
+        assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", credentials.getSmfTlsHost());
+    }
 
-		// Check REST
-		assertThat(credentials.getRestUris(), is(Collections.singletonList("http://192.168.1.50:7018")));
-		assertThat(credentials.getRestTlsUris(), is(Collections.singletonList("https://192.168.1.50:7019")));
+    @Test
+    void testSingleUserProvidedPubsubService() {
+        List<String> tags = singletonList(PUBSUB_TAG);
 
-		// Check AMQP
-		assertThat(credentials.getAmqpUris(), is(Collections.singletonList("amqp://192.168.1.50:7016")));
-		assertThat(credentials.getAmqpTlsUris(), is(Collections.singletonList("amqps://192.168.1.50:7017")));
+        // Create services
+        List<Map<String, Object>> pubsubServices = new ArrayList<>();
+        pubsubServices.add(createSolacePubsubVcapService(USER_PROVIDED_NAME, USER_PROVIDED_LABEL, tags));
+        setVcapService(createVcapServiceList(pubsubServices));
+        // Validate services credentials were loaded correctly
+        List<SolaceServiceCredentials> solaceServiceCredentialsList = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        assertEquals(1, solaceServiceCredentialsList.size());
+        validateSolaceServiceCredentials(solaceServiceCredentialsList.get(0));
+    }
 
-		// Check Management Interfaces
-		assertThat(credentials.getManagementHostnames(), is(Collections.singletonList("vmr-Medium-VMR-0")));
-		assertEquals("sample-mgmt-username", credentials.getManagementUsername());
-		assertEquals("sample-mgmt-password", credentials.getManagementPassword());
-		assertEquals("vmr-medium-web", credentials.getActiveManagementHostname());
+    private void setVcapService(Map<String, List<Object>> vcapServicesData) {
+        Gson gson = new Gson();
+        String vcapServicesJson = gson.toJson(vcapServicesData);
+        System.out.println(VCAP_SVC_ENV + " = " + vcapServicesJson);
+        environmentVariables.set(VCAP_SVC_ENV, vcapServicesJson);
+    }
 
-		// Check DMR Clusters
-		assertEquals("dmr-cluster-name", credentials.getDmrClusterName());
-		assertEquals("dmr-cluster-password", credentials.getDmrClusterPassword());
-	}
+    /**
+     * @return a representation of the solace service credentials of a solace VCAP service
+     */
+    private Map<String, Object> createServiceCredentials() {
+
+        Map<String, Object> credentials = new HashMap<>();
+
+        credentials.put("clientUsername", "sample-client-username");
+        credentials.put("clientPassword", "sample-client-password");
+        credentials.put("msgVpnName", "sample-msg-vpn");
+        credentials.put("smfHosts", singletonList("tcp://192.168.1.50:7000"));
+        credentials.put("smfTlsHosts", asList("tcps://192.168.1.50:7003", "tcps://192.168.1.51:7003"));
+        credentials.put("smfZipHosts", singletonList("tcp://192.168.1.50:7001"));
+        credentials.put("webMessagingUris", singletonList("http://192.168.1.50:80"));
+        credentials.put("webMessagingTlsUris", singletonList("https://192.168.1.50:80"));
+        credentials.put("jmsJndiUris", singletonList("smf://192.168.1.50:7000"));
+        credentials.put("jmsJndiTlsUris", asList("smfs://192.168.1.50:7003", "smfs://192.168.1.51:7003"));
+        credentials.put("mqttUris", singletonList("tcp://192.168.1.50:7020"));
+        credentials.put("mqttTlsUris", asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021"));
+        credentials.put("mqttWsUris", singletonList("ws://192.168.1.50:7022"));
+        credentials.put("mqttWssUris", asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023"));
+        credentials.put("restUris", singletonList("http://192.168.1.50:7018"));
+        credentials.put("restTlsUris", singletonList("https://192.168.1.50:7019"));
+        credentials.put("amqpUris", singletonList("amqp://192.168.1.50:7016"));
+        credentials.put("amqpTlsUris", singletonList("amqps://192.168.1.50:7017"));
+        credentials.put("managementHostnames", singletonList("vmr-Medium-VMR-0"));
+        credentials.put("managementUsername", "sample-mgmt-username");
+        credentials.put("managementPassword", "sample-mgmt-password");
+        credentials.put("activeManagementHostname", "vmr-medium-web");
+        credentials.put("dmrClusterName", "dmr-cluster-name");
+        credentials.put("dmrClusterPassword", "dmr-cluster-password");
+
+        return credentials;
+    }
+
+    /**
+     * @return a map representation of a single VCAP service listing
+     * i.e.:
+     * {
+     * "binding_name": null,
+     * "credentials": { (credentials) },
+     * "instance_name": "cool-pubsub-service",
+     * "label": "solace-pubsub",
+     * "name": "cool-pubsub-service",
+     * "plan": "standard-plan-3",
+     * "tags": [ (tags) ],
+     * }
+     */
+    private Map<String, Object> createSolacePubsubVcapService(String name, String label, List<String> tags) {
+        Map<String, Object> vcapService = new HashMap<>();
+        vcapService.put("credentials", createServiceCredentials());
+        vcapService.put("label", label);
+        vcapService.put("name", name);
+        vcapService.put("plan", "vmr-shared");
+        vcapService.put("provider", "Solace Systems");
+        vcapService.put("tags", tags);
+
+        return vcapService;
+    }
+
+    private Map<String, Object> createThirdPartyVcapService(String name, String label, List<String> tags) {
+        Map<String, Object> vcapService = new HashMap<>();
+        vcapService.put("credentials", null);
+        vcapService.put("label", label);
+        vcapService.put("name", name);
+        vcapService.put("plan", "dummy-plan");
+        vcapService.put("provider", "Company Name");
+        vcapService.put("tags", tags);
+
+        return vcapService;
+    }
+
+    /**
+     * @return a map representation of the VCAP service listings
+     * This is what would be found at the root of the VCAP_SERVICES environment variable
+     * i.e.:
+     * "solace-pubsub": [
+     * { (service listing) },
+     * { (service listing) }
+     * ],
+     * "user-provided": [
+     * { (service listing) }
+     * ]
+     */
+    private Map<String, List<Object>> createVcapServiceList(List<Map<String, Object>> vcapServices) {
+        Map<String, List<Object>> vcapServiceList = new HashMap<>();
+
+        // Add services to VCAP service list by label
+        for (Map<String, Object> service : vcapServices) {
+            String label = (String) service.get("label");
+
+            if (label != null) {
+                if (vcapServiceList.get(label) == null) {
+                    vcapServiceList.computeIfAbsent(label, value -> new ArrayList<>());
+                    vcapServiceList.put(label, new ArrayList<>());
+                }
+                vcapServiceList.get(label).add(service);
+            }
+        }
+
+        return vcapServiceList;
+    }
+
+    private void validateSolaceServiceCredentials(SolaceServiceCredentials credentials) {
+        // Validate it all got set correctly.
+
+        // Check Top Level stuff
+        assertEquals("sample-client-username", credentials.getClientUsername());
+        assertEquals("sample-client-password", credentials.getClientPassword());
+        assertEquals("sample-msg-vpn", credentials.getMsgVpnName());
+
+        // Check SMF
+        assertEquals("tcp://192.168.1.50:7000", credentials.getSmfHost());
+        assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", credentials.getSmfTlsHost());
+        assertEquals("tcp://192.168.1.50:7001", credentials.getSmfZipHost());
+
+        // Check JMS
+        assertEquals("smf://192.168.1.50:7000", credentials.getJmsJndiUri());
+        assertEquals("smfs://192.168.1.50:7003,smfs://192.168.1.51:7003", credentials.getJmsJndiTlsUri());
+
+        // Check MQTT
+        assertEquals(singletonList("tcp://192.168.1.50:7020"), credentials.getMqttUris());
+        assertEquals(asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021"), credentials.getMqttTlsUris());
+        assertEquals(singletonList("ws://192.168.1.50:7022"), credentials.getMqttWsUris());
+        assertEquals(asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023"), credentials.getMqttWssUris());
+
+        // Check REST
+        assertEquals(singletonList("http://192.168.1.50:7018"), credentials.getRestUris());
+        assertEquals(singletonList("https://192.168.1.50:7019"), credentials.getRestTlsUris());
+
+        // Check AMQP
+        assertEquals(singletonList("amqp://192.168.1.50:7016"), credentials.getAmqpUris());
+        assertEquals(singletonList("amqps://192.168.1.50:7017"), credentials.getAmqpTlsUris());
+
+        // Check Management Interfaces
+        assertEquals(singletonList("vmr-Medium-VMR-0"), credentials.getManagementHostnames());
+        assertEquals("sample-mgmt-username", credentials.getManagementUsername());
+        assertEquals("sample-mgmt-password", credentials.getManagementPassword());
+        assertEquals("vmr-medium-web", credentials.getActiveManagementHostname());
+
+        // Check DMR Clusters
+        assertEquals("dmr-cluster-name", credentials.getDmrClusterName());
+        assertEquals("dmr-cluster-password", credentials.getDmrClusterPassword());
+    }
 }

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -48,11 +48,16 @@
 			<groupId>com.solace.cloud.cloudfoundry</groupId>
 			<artifactId>solace-java-cfenv</artifactId>
 		</dependency>
-
 		<dependency>
-			<groupId>com.github.stefanbirkner</groupId>
-			<artifactId>system-rules</artifactId>
-			<version>1.16.0</version>
+			<groupId>jakarta.jms</groupId>
+			<artifactId>jakarta.jms-api</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+		<!-- Environment variable stubs -->
+		<dependency>
+			<groupId>uk.org.webcompere</groupId>
+			<artifactId>system-stubs-jupiter</artifactId>
+			<version>2.0.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoCloudConfiguration.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoCloudConfiguration.java
@@ -18,10 +18,10 @@
  */
 package com.solace.spring.boot.autoconfigure;
 
-import java.util.List;
-
 import com.solace.services.core.model.SolaceServiceCredentials;
 import com.solace.spring.cloud.core.SolaceServiceCredentialsFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.SpringJCSMPFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -30,30 +30,29 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
-import com.solacesystems.jcsmp.JCSMPProperties;
-import com.solacesystems.jcsmp.SpringJCSMPFactory;
+import java.util.List;
 
 @Configuration
 @AutoConfigureBefore(SolaceJavaAutoConfiguration.class)
-@ConditionalOnClass({ JCSMPProperties.class})
+@ConditionalOnClass(JCSMPProperties.class)
 @ConditionalOnMissingBean(SpringJCSMPFactory.class)
 @EnableConfigurationProperties(SolaceJavaProperties.class)
 @Conditional(CloudCondition.class)
 public class SolaceJavaAutoCloudConfiguration extends SolaceJavaAutoConfigurationBase {
 
-	@Autowired
-	public SolaceJavaAutoCloudConfiguration(SolaceJavaProperties properties) {
-		super(properties);
-	}
+    @Autowired
+    public SolaceJavaAutoCloudConfiguration(SolaceJavaProperties properties) {
+        super(properties);
+    }
 
-	@Override
-	public List<SolaceServiceCredentials> getSolaceServiceCredentials() {
-		return SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-	}
+    @Override
+    public List<SolaceServiceCredentials> getSolaceServiceCredentials() {
+        return SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+    }
 
-	@Override
-	SolaceServiceCredentials findFirstSolaceServiceCredentialsImpl() {
-		List<SolaceServiceCredentials> credentials = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		return credentials.size() == 0 ? null : credentials.get(0);
-	}
+    @Override
+    SolaceServiceCredentials findFirstSolaceServiceCredentialsImpl() {
+        List<SolaceServiceCredentials> credentials = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        return credentials.isEmpty() ? null : credentials.get(0);
+    }
 }

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfiguration.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfiguration.java
@@ -20,6 +20,8 @@ package com.solace.spring.boot.autoconfigure;
 
 import com.solace.services.core.loader.SolaceCredentialsLoader;
 import com.solace.services.core.model.SolaceServiceCredentials;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.SpringJCSMPFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -29,20 +31,17 @@ import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import com.solacesystems.jcsmp.JCSMPProperties;
-import com.solacesystems.jcsmp.SpringJCSMPFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
 @AutoConfigureBefore(JmsAutoConfiguration.class)
 @AutoConfigureAfter(SolaceJavaAutoCloudConfiguration.class)
-@ConditionalOnClass({JCSMPProperties.class})
+@ConditionalOnClass(JCSMPProperties.class)
 @ConditionalOnMissingBean(SpringJCSMPFactory.class)
 @EnableConfigurationProperties(SolaceJavaProperties.class)
 public class SolaceJavaAutoConfiguration extends SolaceJavaAutoConfigurationBase {
-    private SolaceCredentialsLoader solaceServicesInfoLoader = new SolaceCredentialsLoader();
+    private final SolaceCredentialsLoader solaceServicesInfoLoader = new SolaceCredentialsLoader();
 
     @Autowired
     public SolaceJavaAutoConfiguration(SolaceJavaProperties properties) {

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationBase.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationBase.java
@@ -9,7 +9,6 @@ import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -23,9 +22,6 @@ abstract class SolaceJavaAutoConfigurationBase implements SpringJCSMPFactoryClou
     }
 
     abstract SolaceServiceCredentials findFirstSolaceServiceCredentialsImpl();
-
-    @Override
-    public abstract List<SolaceServiceCredentials> getSolaceServiceCredentials();
 
     @Bean
     @ConditionalOnMissingBean
@@ -66,8 +62,8 @@ abstract class SolaceJavaAutoConfigurationBase implements SpringJCSMPFactoryClou
     @Override
     public JCSMPProperties getJCSMPProperties(SolaceServiceCredentials solaceServiceCredentials) {
         Properties p = new Properties();
-        Set<Map.Entry<String,String>> set = properties.getApiProperties().entrySet();
-        for (Map.Entry<String,String> entry : set) {
+        Set<Map.Entry<String, String>> set = properties.getApiProperties().entrySet();
+        for (Map.Entry<String, String> entry : set) {
             p.put("jcsmp." + entry.getKey(), entry.getValue());
         }
 

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solacesystems/jcsmp/SpringJCSMPFactory.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/solacesystems/jcsmp/SpringJCSMPFactory.java
@@ -24,7 +24,7 @@ package com.solacesystems.jcsmp;
  */
 public class SpringJCSMPFactory {
     
-    protected JCSMPProperties jcsmpProperties;
+    protected final JCSMPProperties jcsmpProperties;
 
     public SpringJCSMPFactory(JCSMPProperties properties) {
         this.jcsmpProperties = (JCSMPProperties)properties.clone();

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration,\
-com.solace.spring.boot.autoconfigure.SolaceJavaAutoCloudConfiguration

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.solace.spring.boot.autoconfigure.SolaceJavaAutoConfiguration
+com.solace.spring.boot.autoconfigure.SolaceJavaAutoCloudConfiguration

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoCloudConfigurationTest.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoCloudConfigurationTest.java
@@ -18,13 +18,23 @@
  */
 package com.solace.spring.boot.autoconfigure;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.runners.Parameterized.Parameters;
-import static org.junit.runners.Parameterized.Parameter;
+import com.solace.services.core.model.SolaceServiceCredentials;
+import com.solacesystems.jcsmp.JCSMPChannelProperties;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.SpringJCSMPFactory;
+import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.Environment;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -32,59 +42,50 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.solace.services.core.model.SolaceServiceCredentials;
-import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.core.ResolvableType;
-import org.springframework.core.env.Environment;
+import static org.junit.jupiter.api.Assertions.*;
 
-import com.solacesystems.jcsmp.InvalidPropertiesException;
-import com.solacesystems.jcsmp.JCSMPChannelProperties;
-import com.solacesystems.jcsmp.JCSMPProperties;
-import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.SpringJCSMPFactory;
-import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
-
-@RunWith(Parameterized.class)
+@ExtendWith(SystemStubsExtension.class)
 public class SolaceJavaAutoCloudConfigurationTest<T> extends SolaceJavaAutoConfigurationTestBase {
-	// Just enough to satisfy the Cloud Condition we need
-	private static String CF_CLOUD_APP_ENV = "VCAP_APPLICATION={}";
 
-	// Some other Service
-	private static String CF_VCAP_SERVICES_OTHER = "VCAP_SERVICES={ otherService: [ { id: '1' } , { id: '2' } ]}";
+    @SystemStub
+    private EnvironmentVariables environmentVariables;
 
-    @Parameter(0) public String beanClassName;
-    @Parameter(1) public Class<T> beanClass;
+    private static final String VCAP_SVC_ENV = "VCAP_SERVICES";
+    private static final String VCAP_APP_ENV = "VCAP_APPLICATION";
+    // Just enough to satisfy the Cloud Condition we need
+    private static final String CF_CLOUD_APP_ENV = VCAP_APP_ENV + "={}";
+
+    // Some other Service
+    private static final String CF_VCAP_SERVICES_OTHER = VCAP_SVC_ENV + "={ otherService: [ { id: '1' } , { id: '2' } ]}";
+
     public SolaceJavaAutoCloudConfigurationTest() {
         super(SolaceJavaAutoCloudConfiguration.class);
     }
 
-    @Parameters(name = "{0}")
     public static Collection<Object[]> parameterData() {
-		Set<ResolvableType> classes = new HashSet<>();
-		classes.add(ResolvableType.forClass(SpringJCSMPFactoryCloudFactory.class));
-		classes.add(ResolvableType.forClass(SpringJCSMPFactory.class));
-		classes.add(ResolvableType.forClass(JCSMPProperties.class));
-		classes.add(ResolvableType.forClass(SolaceServiceCredentials.class));
+        Set<ResolvableType> classes = new HashSet<>();
+        classes.add(ResolvableType.forClass(SpringJCSMPFactoryCloudFactory.class));
+        classes.add(ResolvableType.forClass(SpringJCSMPFactory.class));
+        classes.add(ResolvableType.forClass(JCSMPProperties.class));
+        classes.add(ResolvableType.forClass(SolaceServiceCredentials.class));
         return getTestParameters(classes);
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
-    public void noBeanNotCloud() throws NoSuchBeanDefinitionException {
+    @ParameterizedTest
+    @MethodSource("parameterData")
+    void noBeanNotCloud(String beanClassName, Class<?> beanClass) {
         load("");
-        try {
-            this.context.getBean(beanClass);
-        } catch(NoSuchBeanDefinitionException e) {
-            assertTrue(e.getBeanType().isAssignableFrom(beanClass));
-            throw e;
-        }
+        verifyNoSuchBeanDefinitionOnGetBean(beanClass);
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
-    public void noBeanIsCloudNoService() throws NoSuchBeanDefinitionException {
+    private void verifyNoSuchBeanDefinitionOnGetBean(Class<?> beanClass) {
+        NoSuchBeanDefinitionException exception = assertThrows(NoSuchBeanDefinitionException.class, () -> this.context.getBean(beanClass));
+        assertTrue(exception.getBeanType().isAssignableFrom(beanClass));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameterData")
+    void noBeanIsCloudNoService(String beanClassName, Class<?> beanClass) {
         load(CF_CLOUD_APP_ENV);
 
         Environment env = context.getEnvironment();
@@ -95,16 +96,12 @@ public class SolaceJavaAutoCloudConfigurationTest<T> extends SolaceJavaAutoConfi
         String VCAP_SERVICES = env.getProperty("VCAP_SERVICES");
         assertNull(VCAP_SERVICES);
 
-        try {
-            this.context.getBean(beanClass);
-        } catch(NoSuchBeanDefinitionException e) {
-            assertTrue(e.getBeanType().isAssignableFrom(beanClass));
-            throw e;
-        }
+        verifyNoSuchBeanDefinitionOnGetBean(beanClass);
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
-    public void noBeanIsCloudWrongService() throws NoSuchBeanDefinitionException {
+    @ParameterizedTest
+    @MethodSource("parameterData")
+    void noBeanIsCloudWrongService(String beanClassName, Class<?> beanClass) {
         load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES_OTHER);
 
         Environment env = context.getEnvironment();
@@ -116,21 +113,15 @@ public class SolaceJavaAutoCloudConfigurationTest<T> extends SolaceJavaAutoConfi
         assertNotNull(VCAP_SERVICES);
         assertFalse(VCAP_SERVICES.contains("solace-pubsub"));
 
-        try {
-            this.context.getBean(beanClass);
-        } catch(NoSuchBeanDefinitionException e) {
-            assertTrue(e.getBeanType().isAssignableFrom(beanClass));
-            throw e;
-        }
+        verifyNoSuchBeanDefinitionOnGetBean(beanClass);
     }
 
-    //@Test
-	// TODO: fix test
-    public void hasBeanIsCloudHasService() {
-        makeCloudEnv();
-
-        String JSONString = addOneSolaceService("VCAP_SERVICES");
-        String CF_VCAP_SERVICES = "VCAP_SERVICES={ \"solace-pubsub\": [" + JSONString + "] }";
+    @ParameterizedTest
+    @MethodSource("parameterData")
+    void hasBeanIsCloudHasService(String beanClassName, Class<T> beanClass) {
+        EnvConfig configuration = getOneSolaceService(VCAP_SVC_ENV);
+        makeCloudEnv(configuration.envValue());
+        String CF_VCAP_SERVICES = configuration.envName() + "=" + configuration.envValue();
 
         load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES);
 
@@ -152,175 +143,166 @@ public class SolaceJavaAutoCloudConfigurationTest<T> extends SolaceJavaAutoConfi
             assertNotNull(springJCSMPFactoryCloudFactory.getSpringJCSMPFactory());
             List<SolaceServiceCredentials> availableServices = springJCSMPFactoryCloudFactory.getSolaceServiceCredentials();
             assertNotNull(availableServices);
-            assertEquals(1,availableServices.size());
+            assertEquals(1, availableServices.size());
         } else if (beanClass.equals(JCSMPProperties.class)) {
             new SpringJCSMPFactory((JCSMPProperties) bean);
         }
     }
 
-	@Test
-	public void isCloudConfiguredBySolaceMessagingInfoAndDefaultsForOtherProperties() throws InvalidPropertiesException {
+    @Test
+    void isCloudConfiguredBySolaceMessagingInfoAndDefaultsForOtherProperties() throws Exception {
+        EnvConfig configuration = getOneSolaceService(VCAP_SVC_ENV);
+        makeCloudEnv(configuration.envValue());
+        String CF_VCAP_SERVICES = configuration.envName() + "=" + configuration.envValue();
 
-		makeCloudEnv();
+        load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES);
 
-		String JSONString = addOneSolaceService("VCAP_SERVICES");
-		String CF_VCAP_SERVICES = "VCAP_SERVICES={ \"solace-pubsub\": [" + JSONString + "] }";
+        SpringJCSMPFactoryCloudFactory springJCSMPFactoryCloudFactory = this.context
+                .getBean(SpringJCSMPFactoryCloudFactory.class);
+        assertNotNull(springJCSMPFactoryCloudFactory);
 
-		load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES);
+        SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
+        assertNotNull(jcsmpFactory);
 
-		SpringJCSMPFactoryCloudFactory springJCSMPFactoryCloudFactory = this.context
-				.getBean(SpringJCSMPFactoryCloudFactory.class);
-		assertNotNull(springJCSMPFactoryCloudFactory);
+        JCSMPSession session = jcsmpFactory.createSession();
+        assertNotNull(session);
 
-		SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
-		assertNotNull(jcsmpFactory);
+        // The are cloud provided (SolaceMessagingInfo) properties
+        assertEquals("tcp://192.168.1.50:7000", session.getProperty(JCSMPProperties.HOST));
+        assertEquals("sample-msg-vpn", session.getProperty(JCSMPProperties.VPN_NAME));
+        assertEquals("sample-client-username", session.getProperty(JCSMPProperties.USERNAME));
+        assertEquals("sample-client-password", session.getProperty(JCSMPProperties.PASSWORD));
 
-		JCSMPSession session = jcsmpFactory.createSession();
-		assertNotNull(session);
+        // Other non cloud (SolaceMessagingInfo) provided properties
+        assertEquals(JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO,
+                session.getProperty(JCSMPProperties.MESSAGE_ACK_MODE));
+        assertEquals(Boolean.FALSE, session.getProperty(JCSMPProperties.REAPPLY_SUBSCRIPTIONS));
+        assertNotNull(session.getProperty(JCSMPProperties.CLIENT_NAME));
+        // Channel properties
+        JCSMPChannelProperties cp = (JCSMPChannelProperties) session
+                .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
+        assertEquals(1, cp.getConnectRetries());
+        assertEquals(5, cp.getReconnectRetries());
+        assertEquals(20, cp.getConnectRetriesPerHost());
+        assertEquals(3000, cp.getReconnectRetryWaitInMillis());
+    }
 
-		// The are cloud provided (SolaceMessagingInfo) properties
-		assertEquals("tcp://192.168.1.50:7000", (String) session.getProperty(JCSMPProperties.HOST));
-		assertEquals("sample-msg-vpn", (String) session.getProperty(JCSMPProperties.VPN_NAME));
-		assertEquals("sample-client-username", (String) session.getProperty(JCSMPProperties.USERNAME));
-		assertEquals("sample-client-password", (String) session.getProperty(JCSMPProperties.PASSWORD));
+    @Test
+    void isCloudConfiguredByUserProvidedServices() throws Exception {
+        EnvConfig configuration = getOneUserProvidedSolaceService(VCAP_SVC_ENV);
+        makeCloudEnv(configuration.envValue());
+        String CF_VCAP_SERVICES = configuration.envName() + "=" + configuration.envValue();
 
-		// Other non cloud (SolaceMessagingInfo) provided properties
-		assertEquals(JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO,
-				(String) session.getProperty(JCSMPProperties.MESSAGE_ACK_MODE));
-		assertEquals(Boolean.FALSE, (Boolean) session.getProperty(JCSMPProperties.REAPPLY_SUBSCRIPTIONS));
-		assertNotNull((String) session.getProperty(JCSMPProperties.CLIENT_NAME));
-		// Channel properties
-		JCSMPChannelProperties cp = (JCSMPChannelProperties) session
-				.getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
-		assertEquals(1, (int) cp.getConnectRetries());
-		assertEquals(5, (int) cp.getReconnectRetries());
-		assertEquals(20, (int) cp.getConnectRetriesPerHost());
-		assertEquals(3000, (int) cp.getReconnectRetryWaitInMillis());
-	}
+        load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES);
 
-        @Test
-        public void isCloudConfiguredByUserProvidedServices() throws InvalidPropertiesException {
+        SpringJCSMPFactoryCloudFactory springJCSMPFactoryCloudFactory = this.context
+                .getBean(SpringJCSMPFactoryCloudFactory.class);
+        assertNotNull(springJCSMPFactoryCloudFactory);
 
-                makeCloudEnv();
+        SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
+        assertNotNull(jcsmpFactory);
 
-                String JSONString = addOneUserProvidedSolaceService("VCAP_SERVICES");
-                String CF_VCAP_SERVICES = "VCAP_SERVICES={ \"user-provided\": [" + JSONString + "] }";
+        JCSMPSession session = jcsmpFactory.createSession();
+        assertNotNull(session);
 
-                load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES);
+        // They are cloud provided (SolaceMessagingInfo) properties
+        assertEquals("tcp://192.168.1.51:7000", session.getProperty(JCSMPProperties.HOST));
+        assertEquals("sample-msg-vpn2", session.getProperty(JCSMPProperties.VPN_NAME));
+        assertEquals("sample-client-username2", session.getProperty(JCSMPProperties.USERNAME));
+        assertEquals("sample-client-password2", session.getProperty(JCSMPProperties.PASSWORD));
 
-                SpringJCSMPFactoryCloudFactory springJCSMPFactoryCloudFactory = this.context
-                                .getBean(SpringJCSMPFactoryCloudFactory.class);
-                assertNotNull(springJCSMPFactoryCloudFactory);
+        // Other non cloud (SolaceMessagingInfo) provided properties
+        assertEquals(JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO,
+                session.getProperty(JCSMPProperties.MESSAGE_ACK_MODE));
+        assertEquals(Boolean.FALSE, session.getProperty(JCSMPProperties.REAPPLY_SUBSCRIPTIONS));
+        assertNotNull(session.getProperty(JCSMPProperties.CLIENT_NAME));
+        // Channel properties
+        JCSMPChannelProperties cp = (JCSMPChannelProperties) session
+                .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
+        assertEquals(1, cp.getConnectRetries());
+        assertEquals(5, cp.getReconnectRetries());
+        assertEquals(20, cp.getConnectRetriesPerHost());
+        assertEquals(3000, cp.getReconnectRetryWaitInMillis());
+    }
 
-                SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
-                assertNotNull(jcsmpFactory);
+    @Test
+    void isCloudConfiguredBySolaceMessagingInfoAndOtherProperties() throws Exception {
+        EnvConfig configuration = getOneSolaceService(VCAP_SVC_ENV);
+        makeCloudEnv(configuration.envValue());
+        String CF_VCAP_SERVICES = configuration.envName() + "=" + configuration.envValue();
 
-                JCSMPSession session = jcsmpFactory.createSession();
-                assertNotNull(session);
+        load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES, "solace.java.host=192.168.1.80:55500", "solace.java.clientUsername=bob",
+                "solace.java.clientPassword=password", "solace.java.msgVpn=newVpn",
+                "solace.java.clientName=client-name", "solace.java.connectRetries=5", "solace.java.reconnectRetries=10",
+                "solace.java.connectRetriesPerHost=40", "solace.java.reconnectRetryWaitInMillis=1000",
+                "solace.java.messageAckMode=client_ack", "solace.java.reapplySubscriptions=true",
+                "solace.java.advanced.jcsmp.TOPIC_DISPATCH=true");
 
-                // The are cloud provided (SolaceMessagingInfo) properties
-                assertEquals("tcp://192.168.1.51:7000", (String) session.getProperty(JCSMPProperties.HOST));
-                assertEquals("sample-msg-vpn2", (String) session.getProperty(JCSMPProperties.VPN_NAME));
-                assertEquals("sample-client-username2", (String) session.getProperty(JCSMPProperties.USERNAME));
-                assertEquals("sample-client-password2", (String) session.getProperty(JCSMPProperties.PASSWORD));
+        SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
+        JCSMPSession session = jcsmpFactory.createSession();
 
-                // Other non cloud (SolaceMessagingInfo) provided properties
-                assertEquals(JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO,
-                                (String) session.getProperty(JCSMPProperties.MESSAGE_ACK_MODE));
-                assertEquals(Boolean.FALSE, (Boolean) session.getProperty(JCSMPProperties.REAPPLY_SUBSCRIPTIONS));
-                assertNotNull((String) session.getProperty(JCSMPProperties.CLIENT_NAME));
-                // Channel properties
-                JCSMPChannelProperties cp = (JCSMPChannelProperties) session
-                                .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
-                assertEquals(1, (int) cp.getConnectRetries());
-                assertEquals(5, (int) cp.getReconnectRetries());
-                assertEquals(20, (int) cp.getConnectRetriesPerHost());
-                assertEquals(3000, (int) cp.getReconnectRetryWaitInMillis());
-        }
+        // The are cloud provided (SolaceMessagingInfo) properties
+        assertEquals("tcp://192.168.1.50:7000", session.getProperty(JCSMPProperties.HOST));
+        assertEquals("sample-msg-vpn", session.getProperty(JCSMPProperties.VPN_NAME));
+        assertEquals("sample-client-username", session.getProperty(JCSMPProperties.USERNAME));
+        assertEquals("sample-client-password", session.getProperty(JCSMPProperties.PASSWORD));
 
-	@Test
-	public void isCloudConfiguredBySolaceMessagingInfoAndOtherProperties() throws InvalidPropertiesException {
-		makeCloudEnv();
+        // Other non cloud provided properties..
+        assertEquals("client-name", session.getProperty(JCSMPProperties.CLIENT_NAME));
+        // Channel properties
+        JCSMPChannelProperties cp = (JCSMPChannelProperties) session
+                .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
+        assertEquals(5, cp.getConnectRetries());
+        assertEquals(10, cp.getReconnectRetries());
+        assertEquals(40, cp.getConnectRetriesPerHost());
+        assertEquals(1000, cp.getReconnectRetryWaitInMillis());
+    }
 
-		String JSONString = addOneSolaceService("VCAP_SERVICES");
-		String CF_VCAP_SERVICES = "VCAP_SERVICES={ \"solace-pubsub\": [" + JSONString + "] }";
+    @Test
+    void isCloudConfiguredBySolaceMessagingInfoAndOtherPropertiesWhenMissingCredentials() throws Exception {
+        Map<String, Object> services = createOneService();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> credentials = (Map<String, Object>) services.get("credentials");
+        credentials.remove("clientUsername");
+        credentials.remove("clientPassword");
 
-		load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES, "solace.java.host=192.168.1.80:55500", "solace.java.clientUsername=bob",
-				"solace.java.clientPassword=password", "solace.java.msgVpn=newVpn",
-				"solace.java.clientName=client-name", "solace.java.connectRetries=5", "solace.java.reconnectRetries=10",
-				"solace.java.connectRetriesPerHost=40", "solace.java.reconnectRetryWaitInMillis=1000",
-				"solace.java.messageAckMode=client_ack", "solace.java.reapplySubscriptions=true",
-				"solace.java.advanced.jcsmp.TOPIC_DISPATCH=true");
+        JSONObject jsonMapObject = new JSONObject(services);
+        String JSONString = jsonMapObject.toString();
+        String vcapService = "{ \"solace-pubsub\": [" + JSONString + "] }";
 
-		SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
-		JCSMPSession session = jcsmpFactory.createSession();
+        makeCloudEnv(vcapService);
+        String CF_VCAP_SERVICES = VCAP_SVC_ENV + "=" + vcapService;
+        load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES, "solace.java.host=192.168.1.80:55500", "solace.java.clientUsername=bob",
+                "solace.java.clientPassword=password", "solace.java.msgVpn=newVpn",
+                "solace.java.clientName=client-name", "solace.java.connectRetries=5", "solace.java.reconnectRetries=10",
+                "solace.java.connectRetriesPerHost=40", "solace.java.reconnectRetryWaitInMillis=1000",
+                "solace.java.messageAckMode=client_ack", "solace.java.reapplySubscriptions=true",
+                "solace.java.advanced.jcsmp.TOPIC_DISPATCH=true");
 
-		// The are cloud provided (SolaceMessagingInfo) properties
-		assertEquals("tcp://192.168.1.50:7000", (String) session.getProperty(JCSMPProperties.HOST));
-		assertEquals("sample-msg-vpn", (String) session.getProperty(JCSMPProperties.VPN_NAME));
-		assertEquals("sample-client-username", (String) session.getProperty(JCSMPProperties.USERNAME));
-		assertEquals("sample-client-password", (String) session.getProperty(JCSMPProperties.PASSWORD));
+        SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
+        JCSMPSession session = jcsmpFactory.createSession();
 
-		// Other non cloud provided properties..
-		assertEquals("client-name", (String) session.getProperty(JCSMPProperties.CLIENT_NAME));
-		// Channel properties
-		JCSMPChannelProperties cp = (JCSMPChannelProperties) session
-				.getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
-		assertEquals(5, (int) cp.getConnectRetries());
-		assertEquals(10, (int) cp.getReconnectRetries());
-		assertEquals(40, (int) cp.getConnectRetriesPerHost());
-		assertEquals(1000, (int) cp.getReconnectRetryWaitInMillis());
-	}
+        // The are cloud provided (SolaceMessagingInfo) properties
+        assertEquals("tcp://192.168.1.50:7000", session.getProperty(JCSMPProperties.HOST));
+        assertEquals("sample-msg-vpn", session.getProperty(JCSMPProperties.VPN_NAME));
+        assertEquals("bob", session.getProperty(JCSMPProperties.USERNAME));
+        assertEquals("password", session.getProperty(JCSMPProperties.PASSWORD));
 
-	@Test
-	public void isCloudConfiguredBySolaceMessagingInfoAndOtherPropertiesWhenMissingCredentials() throws InvalidPropertiesException {
-		makeCloudEnv();
+        // Other non cloud provided properties..
+        assertEquals("client-name", session.getProperty(JCSMPProperties.CLIENT_NAME));
+        // Channel properties
+        JCSMPChannelProperties cp = (JCSMPChannelProperties) session
+                .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
+        assertEquals(5, cp.getConnectRetries());
+        assertEquals(10, cp.getReconnectRetries());
+        assertEquals(40, cp.getConnectRetriesPerHost());
+        assertEquals(1000, cp.getReconnectRetryWaitInMillis());
+    }
 
-		Map<String, Object> services = createOneService();
-		@SuppressWarnings("unchecked")
-		Map<String, Object> credentials = (Map<String, Object>)services.get("credentials");
-		credentials.remove("clientUsername");
-		credentials.remove("clientPassword");
-
-
-		JSONObject jsonMapObject = new JSONObject(services);
-		String JSONString = jsonMapObject.toString();
-		environmentVariables.set("VCAP_SERVICES", "{ \"solace-pubsub\": [" + JSONString + "] }");
-
-
-		String CF_VCAP_SERVICES = "VCAP_SERVICES={ \"solace-pubsub\": [" + JSONString + "] }";
-
-		load(CF_CLOUD_APP_ENV, CF_VCAP_SERVICES, "solace.java.host=192.168.1.80:55500", "solace.java.clientUsername=bob",
-				"solace.java.clientPassword=password", "solace.java.msgVpn=newVpn",
-				"solace.java.clientName=client-name", "solace.java.connectRetries=5", "solace.java.reconnectRetries=10",
-				"solace.java.connectRetriesPerHost=40", "solace.java.reconnectRetryWaitInMillis=1000",
-				"solace.java.messageAckMode=client_ack", "solace.java.reapplySubscriptions=true",
-				"solace.java.advanced.jcsmp.TOPIC_DISPATCH=true");
-
-		SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
-		JCSMPSession session = jcsmpFactory.createSession();
-
-		// The are cloud provided (SolaceMessagingInfo) properties
-		assertEquals("tcp://192.168.1.50:7000", (String) session.getProperty(JCSMPProperties.HOST));
-		assertEquals("sample-msg-vpn", (String) session.getProperty(JCSMPProperties.VPN_NAME));
-		assertEquals("bob", (String) session.getProperty(JCSMPProperties.USERNAME));
-		assertEquals("password", (String) session.getProperty(JCSMPProperties.PASSWORD));
-
-		// Other non cloud provided properties..
-		assertEquals("client-name", (String) session.getProperty(JCSMPProperties.CLIENT_NAME));
-		// Channel properties
-		JCSMPChannelProperties cp = (JCSMPChannelProperties) session
-				.getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
-		assertEquals(5, (int) cp.getConnectRetries());
-		assertEquals(10, (int) cp.getReconnectRetries());
-		assertEquals(40, (int) cp.getConnectRetriesPerHost());
-		assertEquals(1000, (int) cp.getReconnectRetryWaitInMillis());
-	}
-
-	private void makeCloudEnv() {
-		// To force the detection of spring cloud connector which uses
-		// EnvironmentAccessor
-		environmentVariables.set("VCAP_APPLICATION", "{}");
-		assertEquals("{}", System.getenv("VCAP_APPLICATION"));
-	}
+    private void makeCloudEnv(String vcapService) {
+        environmentVariables.set(VCAP_APP_ENV, "{}");
+        assertEquals("{}", System.getenv(VCAP_APP_ENV));
+        environmentVariables.set(VCAP_SVC_ENV, vcapService);
+        assertEquals(vcapService, System.getenv(VCAP_SVC_ENV));
+    }
 }

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationBaseTest.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationBaseTest.java
@@ -8,8 +8,8 @@ import com.solacesystems.jcsmp.JCSMPChannelProperties;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.SpringJCSMPFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -17,21 +17,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SolaceJavaAutoConfigurationBaseTest extends SolaceJavaAutoConfigurationTestBase {
-    private SolaceJavaProperties solaceJavaProperties = getSolaceJavaProperties();
+    private final SolaceJavaProperties solaceJavaProperties = getSolaceJavaProperties();
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private SolaceJavaAutoConfigurationBase jcsmpAutoConfBase;
     private SolaceServiceCredentials solaceServiceCredentials;
-    private ObjectMapper objectMapper = new ObjectMapper();
 
     public SolaceJavaAutoConfigurationBaseTest() {
         super(SolaceJavaAutoConfigurationBase.class);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         SolaceServiceCredentialsImpl solaceServiceCredentialsImpl = objectMapper
                 .convertValue(createOneService().get("credentials"), SolaceServiceCredentialsImpl.class);
@@ -46,52 +44,52 @@ public class SolaceJavaAutoConfigurationBaseTest extends SolaceJavaAutoConfigura
     }
 
     @Test
-    public void testFindFirstSolaceServiceCredentials() {
+    void testFindFirstSolaceServiceCredentials() {
         assertEquals(solaceServiceCredentials, jcsmpAutoConfBase.findFirstSolaceServiceCredentials());
     }
 
     @Test
-    public void testGetSolaceServiceCredentials() {
+    void testGetSolaceServiceCredentials() {
         assertEquals(Collections.singletonList(solaceServiceCredentials), jcsmpAutoConfBase.getSolaceServiceCredentials());
     }
 
     @Test
-    public void testGetSpringJCSMPFactory() throws InvalidPropertiesException {
+    void testGetSpringJCSMPFactory() throws InvalidPropertiesException {
         validateJCSMPFactory(jcsmpAutoConfBase.getSpringJCSMPFactory().createSession(), false);
         disableSolaceServiceCredentials();
         validateJCSMPFactory(jcsmpAutoConfBase.getSpringJCSMPFactory().createSession(), true);
     }
 
     @Test
-    public void testGetSpringJCSMPFactoryByCreds() throws InvalidPropertiesException {
+    void testGetSpringJCSMPFactoryByCreds() throws InvalidPropertiesException {
         validateJCSMPFactory(jcsmpAutoConfBase.getSpringJCSMPFactory(solaceServiceCredentials).createSession(), false);
         disableSolaceServiceCredentials();
         validateJCSMPFactory(jcsmpAutoConfBase.getSpringJCSMPFactory(solaceServiceCredentials).createSession(), false);
     }
 
     @Test
-    public void testGetSpringJCSMPFactoryById() throws InvalidPropertiesException {
+    void testGetSpringJCSMPFactoryById() throws InvalidPropertiesException {
         validateJCSMPFactory(jcsmpAutoConfBase.getSpringJCSMPFactory(solaceServiceCredentials.getId()).createSession(), false);
         disableSolaceServiceCredentials();
         assertNull(jcsmpAutoConfBase.getSpringJCSMPFactory(solaceServiceCredentials.getId()));
     }
 
     @Test
-    public void testGetJCSMPProperties() throws InvalidPropertiesException {
+    void testGetJCSMPProperties() throws InvalidPropertiesException {
         validateJCSMPProperties(jcsmpAutoConfBase.getJCSMPProperties(), false);
         disableSolaceServiceCredentials();
         validateJCSMPProperties(jcsmpAutoConfBase.getJCSMPProperties(), true);
     }
 
     @Test
-    public void testGetJCSMPPropertiesByCreds() throws InvalidPropertiesException {
+    void testGetJCSMPPropertiesByCreds() throws InvalidPropertiesException {
         validateJCSMPProperties(jcsmpAutoConfBase.getJCSMPProperties(solaceServiceCredentials), false);
         disableSolaceServiceCredentials();
         validateJCSMPProperties(jcsmpAutoConfBase.getJCSMPProperties(solaceServiceCredentials), false);
     }
 
     @Test
-    public void testGetJCSMPPropertiesById() throws InvalidPropertiesException {
+    void testGetJCSMPPropertiesById() throws InvalidPropertiesException {
         validateJCSMPProperties(jcsmpAutoConfBase.getJCSMPProperties(solaceServiceCredentials.getId()), false);
         disableSolaceServiceCredentials();
         assertNull(jcsmpAutoConfBase.getJCSMPProperties(solaceServiceCredentials.getId()));
@@ -140,7 +138,7 @@ public class SolaceJavaAutoConfigurationBaseTest extends SolaceJavaAutoConfigura
     }
 
     private void validateApiProperties(JCSMPSession session) {
-        for (Map.Entry<String,String> entry : solaceJavaProperties.getApiProperties().entrySet()) {
+        for (Map.Entry<String, String> entry : solaceJavaProperties.getApiProperties().entrySet()) {
             assertNotNull(session.getProperty("jcsmp." + entry.getKey()));
             assertEquals(session.getProperty("jcsmp." + entry.getKey()), entry.getValue());
         }

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTest.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTest.java
@@ -25,124 +25,128 @@ import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.SpringJCSMPFactory;
 import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SystemStubsExtension.class)
 public class SolaceJavaAutoConfigurationTest extends SolaceJavaAutoConfigurationTestBase {
 
-	public SolaceJavaAutoConfigurationTest() {
-		super(SolaceJavaAutoConfiguration.class);
-	}
+    @SystemStub
+    private EnvironmentVariables environmentVariables;
 
-	@Test
-	public void defaultNativeConnectionFactory() throws InvalidPropertiesException {
-		load("");
-		SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
-		assertNotNull(jcsmpFactory);
-
-		JCSMPSession session = jcsmpFactory.createSession();
-		assertNotNull(session);
-
-		assertEquals("localhost", (String)session.getProperty(JCSMPProperties.HOST));
-        assertEquals("default", (String)session.getProperty(JCSMPProperties.VPN_NAME));
-        assertEquals("spring-default-client-username", (String)session.getProperty(JCSMPProperties.USERNAME) );
-        assertEquals("", (String)session.getProperty(JCSMPProperties.PASSWORD));
-        assertEquals(JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO,(String)session.getProperty(JCSMPProperties.MESSAGE_ACK_MODE));
-        assertEquals(Boolean.FALSE,(Boolean) session.getProperty(JCSMPProperties.REAPPLY_SUBSCRIPTIONS));
-        assertNotNull((String)session.getProperty(JCSMPProperties.CLIENT_NAME));
-        // Channel properties
-        JCSMPChannelProperties cp = (JCSMPChannelProperties) session
-                .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
-        assertEquals(1, (int)cp.getConnectRetries());
-        assertEquals(5, (int)cp.getReconnectRetries());
-        assertEquals(20, (int)cp.getConnectRetriesPerHost());
-        assertEquals(3000, (int)cp.getReconnectRetryWaitInMillis());
+    public SolaceJavaAutoConfigurationTest() {
+        super(SolaceJavaAutoConfiguration.class);
     }
 
-	@Test
-	public void customNativeConnectionFactory() throws InvalidPropertiesException {
-		load("solace.java.host=192.168.1.80:55500",
-				"solace.java.clientUsername=bob", "solace.java.clientPassword=password",
-				"solace.java.msgVpn=newVpn", "solace.java.clientName=client-name",
-				"solace.java.connectRetries=5", "solace.java.reconnectRetries=10",
-				"solace.java.connectRetriesPerHost=40", "solace.java.reconnectRetryWaitInMillis=1000",
-				"solace.java.messageAckMode=client_ack","solace.java.reapplySubscriptions=true",
-				"solace.java.advanced.jcsmp.TOPIC_DISPATCH=true");
+    @Test
+    void defaultNativeConnectionFactory() throws InvalidPropertiesException {
+        load("");
+        SpringJCSMPFactory jcsmpFactory = context.getBean(SpringJCSMPFactory.class);
+        assertNotNull(jcsmpFactory);
 
-		SpringJCSMPFactory jcsmpFactory = this.context.getBean(SpringJCSMPFactory.class);
-		assertNotNull(jcsmpFactory);
         JCSMPSession session = jcsmpFactory.createSession();
         assertNotNull(session);
 
-        assertEquals("192.168.1.80:55500", (String)session.getProperty(JCSMPProperties.HOST));
-        assertEquals("newVpn", (String)session.getProperty(JCSMPProperties.VPN_NAME));
-        assertEquals("bob", (String)session.getProperty(JCSMPProperties.USERNAME) );
-        assertEquals("password", (String)session.getProperty(JCSMPProperties.PASSWORD) );
-        assertEquals("client-name", (String)session.getProperty(JCSMPProperties.CLIENT_NAME) );
+        assertEquals("localhost", session.getProperty(JCSMPProperties.HOST));
+        assertEquals("default", session.getProperty(JCSMPProperties.VPN_NAME));
+        assertEquals("spring-default-client-username", session.getProperty(JCSMPProperties.USERNAME));
+        assertEquals("", session.getProperty(JCSMPProperties.PASSWORD));
+        assertEquals(JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO, session.getProperty(JCSMPProperties.MESSAGE_ACK_MODE));
+        assertEquals(Boolean.FALSE, session.getProperty(JCSMPProperties.REAPPLY_SUBSCRIPTIONS));
+        assertNotNull(session.getProperty(JCSMPProperties.CLIENT_NAME));
         // Channel properties
         JCSMPChannelProperties cp = (JCSMPChannelProperties) session
                 .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
-        assertEquals(5, (int)cp.getConnectRetries());
-        assertEquals(10, (int)cp.getReconnectRetries());
-        assertEquals(40, (int)cp.getConnectRetriesPerHost());
-        assertEquals(1000, (int)cp.getReconnectRetryWaitInMillis());
-	}
+        assertEquals(1, cp.getConnectRetries());
+        assertEquals(5, cp.getReconnectRetries());
+        assertEquals(20, cp.getConnectRetriesPerHost());
+        assertEquals(3000, cp.getReconnectRetryWaitInMillis());
+    }
 
-	@Test
-	public void externallyLoadedServicePropertiesBasicBeanTest() {
-		// Testing one type of externally loaded service is good enough
-		// The loader has its own tests for the other scenarios
-		String ENV_SOLCAP_SERVICES = "SOLCAP_SERVICES";
+    @Test
+    void customNativeConnectionFactory() throws InvalidPropertiesException {
+        load("solace.java.host=192.168.1.80:55500",
+                "solace.java.clientUsername=bob", "solace.java.clientPassword=password",
+                "solace.java.msgVpn=newVpn", "solace.java.clientName=client-name",
+                "solace.java.connectRetries=5", "solace.java.reconnectRetries=10",
+                "solace.java.connectRetriesPerHost=40", "solace.java.reconnectRetryWaitInMillis=1000",
+                "solace.java.messageAckMode=client_ack", "solace.java.reapplySubscriptions=true",
+                "solace.java.advanced.jcsmp.TOPIC_DISPATCH=true");
 
-		load(String.format("%s={ \"solace-pubsub\": [%s] }",
-				ENV_SOLCAP_SERVICES, addOneSolaceService(ENV_SOLCAP_SERVICES)));
+        SpringJCSMPFactory jcsmpFactory = context.getBean(SpringJCSMPFactory.class);
+        assertNotNull(jcsmpFactory);
+        JCSMPSession session = jcsmpFactory.createSession();
+        assertNotNull(session);
 
-		String solaceManifest = context.getEnvironment().getProperty(ENV_SOLCAP_SERVICES);
-		assertNotNull(solaceManifest);
-		assertTrue(solaceManifest.contains("solace-pubsub"));
+        assertEquals("192.168.1.80:55500", session.getProperty(JCSMPProperties.HOST));
+        assertEquals("newVpn", session.getProperty(JCSMPProperties.VPN_NAME));
+        assertEquals("bob", session.getProperty(JCSMPProperties.USERNAME));
+        assertEquals("password", session.getProperty(JCSMPProperties.PASSWORD));
+        assertEquals("client-name", session.getProperty(JCSMPProperties.CLIENT_NAME));
+        // Channel properties
+        JCSMPChannelProperties cp = (JCSMPChannelProperties) session
+                .getProperty(JCSMPProperties.CLIENT_CHANNEL_PROPERTIES);
+        assertEquals(5, cp.getConnectRetries());
+        assertEquals(10, cp.getReconnectRetries());
+        assertEquals(40, cp.getConnectRetriesPerHost());
+        assertEquals(1000, cp.getReconnectRetryWaitInMillis());
+    }
 
-		assertNotNull(this.context.getBean(SpringJCSMPFactoryCloudFactory.class));
-		assertNotNull(this.context.getBean(SpringJCSMPFactory.class));
-		assertNotNull(this.context.getBean(JCSMPProperties.class));
-		assertNotNull(this.context.getBean(SolaceServiceCredentials.class));
-	}
+    @Test
+    void externallyLoadedServicePropertiesBasicBeanTest() {
+        // Testing one type of externally loaded service is good enough
+        // The loader has its own tests for the other scenarios
+        String ENV_SOLCAP_SERVICES = "SOLCAP_SERVICES";
 
-	@Test
-	public void noExternallyLoadedServicePropertiesBasicBeanTest() {
-		// Testing one type of externally loaded service is good enough
-		// The loader has its own tests for the other scenarios
-		String ENV_SOLCAP_SERVICES = "SOLCAP_SERVICES";
-		load(String.format("%s={ \"solace-pubsub\": [] }", ENV_SOLCAP_SERVICES));
+        EnvConfig configuration = getOneSolaceService(ENV_SOLCAP_SERVICES);
+        environmentVariables.set(configuration.envName(), configuration.envValue());
 
-		String solaceManifest = context.getEnvironment().getProperty(ENV_SOLCAP_SERVICES);
-		assertNotNull(solaceManifest);
-		assertTrue(solaceManifest.contains("solace-pubsub"));
+        load(String.format("%s=%s", ENV_SOLCAP_SERVICES, configuration.envValue()));
 
-		assertNotNull(this.context.getBean(SpringJCSMPFactoryCloudFactory.class));
-		assertNotNull(this.context.getBean(SpringJCSMPFactory.class));
-		assertNotNull(this.context.getBean(JCSMPProperties.class));
-		NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
-				this.context.getBean(SolaceServiceCredentials.class));
-		assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
-	}
+        String solaceManifest = context.getEnvironment().getProperty(ENV_SOLCAP_SERVICES);
+        assertNotNull(solaceManifest);
+        assertTrue(solaceManifest.contains("solace-pubsub"));
 
-	@Test
-	public void applicationPropertiesBasicBeanTest() {
-		load("");
-		assertNotNull(this.context.getBean(SpringJCSMPFactoryCloudFactory.class));
-		assertNotNull(this.context.getBean(SpringJCSMPFactory.class));
-		assertNotNull(this.context.getBean(JCSMPProperties.class));
-		NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
-				this.context.getBean(SolaceServiceCredentials.class));
-		assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
-	}
+        assertNotNull(context.getBean(SpringJCSMPFactoryCloudFactory.class));
+        assertNotNull(context.getBean(SpringJCSMPFactory.class));
+        assertNotNull(context.getBean(JCSMPProperties.class));
+        assertNotNull(context.getBean(SolaceServiceCredentials.class));
+    }
+
+    @Test
+    void noExternallyLoadedServicePropertiesBasicBeanTest() {
+        // Testing one type of externally loaded service is good enough
+        // The loader has its own tests for the other scenarios
+        String ENV_SOLCAP_SERVICES = "SOLCAP_SERVICES";
+        load(String.format("%s={ \"solace-pubsub\": [] }", ENV_SOLCAP_SERVICES));
+
+        String solaceManifest = context.getEnvironment().getProperty(ENV_SOLCAP_SERVICES);
+        assertNotNull(solaceManifest);
+        assertTrue(solaceManifest.contains("solace-pubsub"));
+
+        assertNotNull(context.getBean(SpringJCSMPFactoryCloudFactory.class));
+        assertNotNull(context.getBean(SpringJCSMPFactory.class));
+        assertNotNull(context.getBean(JCSMPProperties.class));
+        NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
+                context.getBean(SolaceServiceCredentials.class));
+        assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
+    }
+
+    @Test
+    void applicationPropertiesBasicBeanTest() {
+        load("");
+        assertNotNull(context.getBean(SpringJCSMPFactoryCloudFactory.class));
+        assertNotNull(context.getBean(SpringJCSMPFactory.class));
+        assertNotNull(context.getBean(JCSMPProperties.class));
+        NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
+                context.getBean(SolaceServiceCredentials.class));
+        assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
+    }
 
 }

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTestBase.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTestBase.java
@@ -2,36 +2,33 @@ package com.solace.spring.boot.autoconfigure;
 
 import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.ResolvableType;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.singletonList;
+
 public abstract class SolaceJavaAutoConfigurationTestBase {
-    @Rule
-    public final EnvironmentVariables environmentVariables;
-
     AnnotationConfigApplicationContext context;
-    private Class<? extends SpringJCSMPFactoryCloudFactory> configClass;
+    private final Class<? extends SpringJCSMPFactoryCloudFactory> configClass;
 
-    @Configuration public static class EmptyConfiguration {}
+    @Configuration
+    public static class EmptyConfiguration {
+    }
 
     SolaceJavaAutoConfigurationTestBase(Class<? extends SpringJCSMPFactoryCloudFactory> configClass) {
         this.configClass = configClass;
-        this.environmentVariables = new EnvironmentVariables();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (this.context != null) {
             this.context.close();
@@ -46,22 +43,22 @@ public abstract class SolaceJavaAutoConfigurationTestBase {
         exCred.put("clientUsername", "sample-client-username");
         exCred.put("clientPassword", "sample-client-password");
         exCred.put("msgVpnName", "sample-msg-vpn");
-        exCred.put("smfHosts", Collections.singletonList("tcp://192.168.1.50:7000"));
+        exCred.put("smfHosts", singletonList("tcp://192.168.1.50:7000"));
         exCred.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.50:7003", "tcps://192.168.1.51:7003"));
-        exCred.put("smfZipHosts", Collections.singletonList("tcp://192.168.1.50:7001"));
-        exCred.put("webMessagingUris", Collections.singletonList("http://192.168.1.50:80"));
-        exCred.put("webMessagingTlsUris", Collections.singletonList("https://192.168.1.50:80"));
-        exCred.put("jmsJndiUris", Collections.singletonList("smf://192.168.1.50:7000"));
+        exCred.put("smfZipHosts", singletonList("tcp://192.168.1.50:7001"));
+        exCred.put("webMessagingUris", singletonList("http://192.168.1.50:80"));
+        exCred.put("webMessagingTlsUris", singletonList("https://192.168.1.50:80"));
+        exCred.put("jmsJndiUris", singletonList("smf://192.168.1.50:7000"));
         exCred.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.50:7003", "smfs://192.168.1.51:7003"));
-        exCred.put("mqttUris", Collections.singletonList("tcp://192.168.1.50:7020"));
+        exCred.put("mqttUris", singletonList("tcp://192.168.1.50:7020"));
         exCred.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021"));
-        exCred.put("mqttWsUris", Collections.singletonList("ws://192.168.1.50:7022"));
+        exCred.put("mqttWsUris", singletonList("ws://192.168.1.50:7022"));
         exCred.put("mqttWssUris", Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023"));
-        exCred.put("restUris", Collections.singletonList("http://192.168.1.50:7018"));
-        exCred.put("restTlsUris", Collections.singletonList("https://192.168.1.50:7019"));
-        exCred.put("amqpUris", Collections.singletonList("amqp://192.168.1.50:7016"));
-        exCred.put("amqpTlsUris", Collections.singletonList("amqps://192.168.1.50:7017"));
-        exCred.put("managementHostnames", Collections.singletonList("vmr-Medium-VMR-0"));
+        exCred.put("restUris", singletonList("http://192.168.1.50:7018"));
+        exCred.put("restTlsUris", singletonList("https://192.168.1.50:7019"));
+        exCred.put("amqpUris", singletonList("amqp://192.168.1.50:7016"));
+        exCred.put("amqpTlsUris", singletonList("amqps://192.168.1.50:7017"));
+        exCred.put("managementHostnames", singletonList("vmr-Medium-VMR-0"));
         exCred.put("managementUsername", "sample-mgmt-username");
         exCred.put("managementPassword", "sample-mgmt-password");
         exCred.put("activeManagementHostname", "vmr-medium-web");
@@ -78,12 +75,12 @@ public abstract class SolaceJavaAutoConfigurationTestBase {
         return exVcapServices;
     }
 
-    String addOneSolaceService(String envName) {
+    EnvConfig getOneSolaceService(String envName) {
         Map<String, Object> services = createOneService();
         JSONObject jsonMapObject = new JSONObject(services);
         String JSONString = jsonMapObject.toString();
-        environmentVariables.set(envName, "{ \"solace-pubsub\": [" + JSONString + "] }");
-        return JSONString;
+        String configuration = "{ \"solace-pubsub\": [" + JSONString + "] }";
+        return new EnvConfig(envName, configuration);
     }
 
     Map<String, Object> createOneUserProvidedService() {
@@ -94,22 +91,22 @@ public abstract class SolaceJavaAutoConfigurationTestBase {
         exCred.put("clientUsername", "sample-client-username2");
         exCred.put("clientPassword", "sample-client-password2");
         exCred.put("msgVpnName", "sample-msg-vpn2");
-        exCred.put("smfHosts", Collections.singletonList("tcp://192.168.1.51:7000"));
+        exCred.put("smfHosts", singletonList("tcp://192.168.1.51:7000"));
         exCred.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.51:7003", "tcps://192.168.1.51:7003"));
-        exCred.put("smfZipHosts", Collections.singletonList("tcp://192.168.1.51:7001"));
-        exCred.put("webMessagingUris", Collections.singletonList("http://192.168.1.51:80"));
-        exCred.put("webMessagingTlsUris", Collections.singletonList("https://192.168.1.51:80"));
-        exCred.put("jmsJndiUris", Collections.singletonList("smf://192.168.1.51:7000"));
+        exCred.put("smfZipHosts", singletonList("tcp://192.168.1.51:7001"));
+        exCred.put("webMessagingUris", singletonList("http://192.168.1.51:80"));
+        exCred.put("webMessagingTlsUris", singletonList("https://192.168.1.51:80"));
+        exCred.put("jmsJndiUris", singletonList("smf://192.168.1.51:7000"));
         exCred.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.51:7003", "smfs://192.168.1.51:7003"));
-        exCred.put("mqttUris", Collections.singletonList("tcp://192.168.1.51:7020"));
+        exCred.put("mqttUris", singletonList("tcp://192.168.1.51:7020"));
         exCred.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.51:7021", "ssl://192.168.1.51:7021"));
-        exCred.put("mqttWsUris", Collections.singletonList("ws://192.168.1.51:7022"));
+        exCred.put("mqttWsUris", singletonList("ws://192.168.1.51:7022"));
         exCred.put("mqttWssUris", Arrays.asList("wss://192.168.1.51:7023", "wss://192.168.1.51:7023"));
-        exCred.put("restUris", Collections.singletonList("http://192.168.1.51:7018"));
-        exCred.put("restTlsUris", Collections.singletonList("https://192.168.1.51:7019"));
-        exCred.put("amqpUris", Collections.singletonList("amqp://192.168.1.51:7016"));
-        exCred.put("amqpTlsUris", Collections.singletonList("amqps://192.168.1.51:7017"));
-        exCred.put("managementHostnames", Collections.singletonList("vmr-Medium-VMR-02"));
+        exCred.put("restUris", singletonList("http://192.168.1.51:7018"));
+        exCred.put("restTlsUris", singletonList("https://192.168.1.51:7019"));
+        exCred.put("amqpUris", singletonList("amqp://192.168.1.51:7016"));
+        exCred.put("amqpTlsUris", singletonList("amqps://192.168.1.51:7017"));
+        exCred.put("managementHostnames", singletonList("vmr-Medium-VMR-02"));
         exCred.put("managementUsername", "sample-mgmt-username2");
         exCred.put("managementPassword", "sample-mgmt-password2");
         exCred.put("activeManagementHostname", "vmr-medium-web2");
@@ -119,20 +116,18 @@ public abstract class SolaceJavaAutoConfigurationTestBase {
         exVcapServices.put("name", "internal-solace-pubsub");
         exVcapServices.put("binding_name", null);
         // no need to check for tags in terms of validation. It's more for
-        exVcapServices.put("tags",
-                Arrays.asList("solace-pubsub"));
+        exVcapServices.put("tags", singletonList("solace-pubsub"));
 
         return exVcapServices;
     }
 
-    String addOneUserProvidedSolaceService(String envName) {
+    EnvConfig getOneUserProvidedSolaceService(String envName) {
         Map<String, Object> services = createOneUserProvidedService();
         JSONObject jsonMapObject = new JSONObject(services);
         String JSONString = jsonMapObject.toString();
-        environmentVariables.set(envName, "{ \"user-provided\": [" + JSONString + "] }");
-        return JSONString;
+        return new EnvConfig(envName, "{ \"user-provided\": [" + JSONString + "] }");
     }
-    
+
     void load(String... environment) {
         load(EmptyConfiguration.class, environment);
     }
@@ -159,5 +154,8 @@ public abstract class SolaceJavaAutoConfigurationTestBase {
             parameters.add(new Object[]{testName.toString(), rawClass});
         }
         return parameters;
+    }
+
+    public record EnvConfig(String envName, String envValue) {
     }
 }

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/pom.xml
@@ -56,11 +56,16 @@
 			<groupId>com.solace.cloud.cloudfoundry</groupId>
 			<artifactId>solace-java-cfenv</artifactId>
 		</dependency>
-
 		<dependency>
-			<groupId>com.github.stefanbirkner</groupId>
-			<artifactId>system-rules</artifactId>
-			<version>1.16.0</version>
+			<groupId>jakarta.jms</groupId>
+			<artifactId>jakarta.jms-api</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+		<!-- Environment variable stubs -->
+		<dependency>
+			<groupId>uk.org.webcompere</groupId>
+			<artifactId>system-stubs-jupiter</artifactId>
+			<version>2.0.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoCloudConfiguration.java
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoCloudConfiguration.java
@@ -18,49 +18,47 @@
  */
 package com.solace.spring.boot.autoconfigure;
 
-import javax.jms.ConnectionFactory;
-
 import com.solace.services.core.model.SolaceServiceCredentials;
 import com.solace.spring.cloud.core.SolaceServiceCredentialsFactory;
+import com.solacesystems.jms.SolConnectionFactory;
+import jakarta.jms.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import com.solacesystems.jms.SolConnectionFactory;
 import org.springframework.jndi.JndiTemplate;
 
 import java.util.List;
 
 @Configuration
-@AutoConfigureBefore(JmsAutoConfiguration.class)
-@ConditionalOnClass({ ConnectionFactory.class, SolConnectionFactory.class })
-@ConditionalOnMissingBean({ ConnectionFactory.class, JndiTemplate.class })
-@Conditional(CloudCondition.class)
+@AutoConfigureBefore(SolaceJmsAutoConfiguration.class)
+@ConditionalOnClass({ConnectionFactory.class, SolConnectionFactory.class})
+@ConditionalOnMissingBean({ConnectionFactory.class, JndiTemplate.class})
 @EnableConfigurationProperties(SolaceJmsProperties.class)
+@Conditional(CloudCondition.class)
 public class SolaceJmsAutoCloudConfiguration extends SolaceJmsAutoConfigurationBase {
 
-	@SuppressWarnings("unused")
-	private static final Logger logger = LoggerFactory.getLogger(SolaceJmsAutoCloudConfiguration.class);
+    @SuppressWarnings("unused")
+    private static final Logger logger = LoggerFactory.getLogger(SolaceJmsAutoCloudConfiguration.class);
 
-	@Autowired
-	public SolaceJmsAutoCloudConfiguration(SolaceJmsProperties properties) {
-		super(properties);
-	}
+    @Autowired
+    public SolaceJmsAutoCloudConfiguration(SolaceJmsProperties properties) {
+        super(properties);
+    }
 
-	@Override
-	SolaceServiceCredentials findFirstSolaceServiceCredentialsImpl() {
-		List<SolaceServiceCredentials> credentials = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-		return credentials.size() == 0 ? null : credentials.get(0);
-	}
+    @Override
+    SolaceServiceCredentials findFirstSolaceServiceCredentialsImpl() {
+        List<SolaceServiceCredentials> credentials = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+        return credentials.isEmpty() ? null : credentials.get(0);
+    }
 
-	@Override
-	public List<SolaceServiceCredentials> getSolaceServiceCredentials() {
-		return SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-	}
+    @Override
+    public List<SolaceServiceCredentials> getSolaceServiceCredentials() {
+        return SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
+    }
 }

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfiguration.java
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfiguration.java
@@ -18,11 +18,12 @@
  */
 package com.solace.spring.boot.autoconfigure;
 
-import javax.jms.ConnectionFactory;
-
 import com.solace.services.core.loader.SolaceCredentialsLoader;
 import com.solace.services.core.model.SolaceServiceCredentials;
+import com.solacesystems.jms.SolConnectionFactory;
+import jakarta.jms.ConnectionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -31,19 +32,18 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jndi.JndiTemplate;
 
-import com.solacesystems.jms.SolConnectionFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
 @AutoConfigureBefore(JmsAutoConfiguration.class)
-@ConditionalOnClass({ ConnectionFactory.class, SolConnectionFactory.class })
-@ConditionalOnMissingBean({ ConnectionFactory.class, JndiTemplate.class })
+@AutoConfigureAfter(SolaceJmsAutoCloudConfiguration.class)
+@ConditionalOnClass({ConnectionFactory.class, SolConnectionFactory.class})
+@ConditionalOnMissingBean({ConnectionFactory.class, JndiTemplate.class})
 @EnableConfigurationProperties(SolaceJmsProperties.class)
 public class SolaceJmsAutoConfiguration extends SolaceJmsAutoConfigurationBase {
 
-    private SolaceCredentialsLoader solaceServicesInfoLoader = new SolaceCredentialsLoader();
+    private final SolaceCredentialsLoader solaceServicesInfoLoader = new SolaceCredentialsLoader();
 
     @Autowired
     public SolaceJmsAutoConfiguration(SolaceJmsProperties properties) {

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationBase.java
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationBase.java
@@ -18,8 +18,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Properties;
 
-import javax.naming.Context;
-import javax.naming.InitialContext;
+import static javax.naming.Context.*;
 
 abstract class SolaceJmsAutoConfigurationBase implements SpringSolJmsConnectionFactoryCloudFactory, SpringSolJmsJndiTemplateCloudFactory {
     private static final Logger logger = LoggerFactory.getLogger(SolaceJmsAutoConfigurationBase.class);
@@ -31,9 +30,6 @@ abstract class SolaceJmsAutoConfigurationBase implements SpringSolJmsConnectionF
     }
 
     abstract SolaceServiceCredentials findFirstSolaceServiceCredentialsImpl();
-
-    @Override
-    public abstract List<SolaceServiceCredentials> getSolaceServiceCredentials();
 
     @Bean
     @ConditionalOnMissingBean
@@ -111,15 +107,15 @@ abstract class SolaceJmsAutoConfigurationBase implements SpringSolJmsConnectionF
 
             Properties env = new Properties();
             env.putAll(properties.getApiProperties());
-            env.put(InitialContext.INITIAL_CONTEXT_FACTORY, "com.solacesystems.jndi.SolJNDIInitialContextFactory");
-            env.put(InitialContext.PROVIDER_URL, credentials.getJmsJndiUri() != null ?
+            env.put(INITIAL_CONTEXT_FACTORY, "com.solacesystems.jndi.SolJNDIInitialContextFactory");
+            env.put(PROVIDER_URL, credentials.getJmsJndiUri() != null ?
                     credentials.getJmsJndiUri() : properties.getHost());
-            env.put(Context.SECURITY_PRINCIPAL,
+            env.put(SECURITY_PRINCIPAL,
                     credentials.getClientUsername() != null && credentials.getMsgVpnName() != null ?
                             credentials.getClientUsername() + '@' + credentials.getMsgVpnName() :
                             properties.getClientUsername() + '@' + properties.getMsgVpn());
 
-            env.put(Context.SECURITY_CREDENTIALS, credentials.getClientPassword() != null ?
+            env.put(SECURITY_CREDENTIALS, credentials.getClientPassword() != null ?
                     credentials.getClientPassword() : properties.getClientPassword());
 
             JndiTemplate jndiTemplate = new JndiTemplate();
@@ -135,6 +131,6 @@ abstract class SolaceJmsAutoConfigurationBase implements SpringSolJmsConnectionF
     @Override
     public JndiTemplate getJndiTemplate(String id) {
         List<SolaceServiceCredentials> credentials = SolaceServiceCredentialsFactory.getAllFromCloudFoundry();
-        return credentials.size() == 0 ? null : getJndiTemplate(credentials.get(0));
+        return credentials.isEmpty() ? null : getJndiTemplate(credentials.get(0));
     }
 }

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.solace.spring.boot.autoconfigure.SolaceJmsAutoCloudConfiguration,\
-com.solace.spring.boot.autoconfigure.SolaceJmsAutoConfiguration

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.solace.spring.boot.autoconfigure.SolaceJmsAutoCloudConfiguration
+com.solace.spring.boot.autoconfigure.SolaceJmsAutoConfiguration

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationBaseTest.java
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationBaseTest.java
@@ -4,29 +4,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solace.services.core.model.SolaceServiceCredentials;
 import com.solace.services.core.model.SolaceServiceCredentialsImpl;
 import com.solacesystems.jms.SolConnectionFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SolaceJmsAutoConfigurationBaseTest extends SolaceJmsAutoConfigurationTestBase {
-    private SolaceJmsProperties solaceJmsProperties = getSolaceJmsProperties();
+    private final SolaceJmsProperties solaceJmsProperties = getSolaceJmsProperties();
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private SolaceJmsAutoConfigurationBase jmsAutoConfBase;
     private SolaceServiceCredentials solaceServiceCredentials;
-    private ObjectMapper objectMapper = new ObjectMapper();
 
     public SolaceJmsAutoConfigurationBaseTest() {
         super(SolaceJmsAutoConfigurationBase.class);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         SolaceServiceCredentialsImpl solaceServiceCredentialsImpl = objectMapper
                 .convertValue(createOneService().get("credentials"), SolaceServiceCredentialsImpl.class);
@@ -41,31 +39,31 @@ public class SolaceJmsAutoConfigurationBaseTest extends SolaceJmsAutoConfigurati
     }
 
     @Test
-    public void testFindFirstSolaceServiceCredentials() {
+    void testFindFirstSolaceServiceCredentials() {
         assertEquals(solaceServiceCredentials, jmsAutoConfBase.findFirstSolaceServiceCredentials());
     }
 
     @Test
-    public void testGetSolaceServiceCredentials() {
+    void testGetSolaceServiceCredentials() {
         assertEquals(Collections.singletonList(solaceServiceCredentials), jmsAutoConfBase.getSolaceServiceCredentials());
     }
 
     @Test
-    public void testGetSolConnectionFactory() {
+    void testGetSolConnectionFactory() {
         validateSolConnectionFactory(jmsAutoConfBase.getSolConnectionFactory(), false);
         disableSolaceServiceCredentials();
         validateSolConnectionFactory(jmsAutoConfBase.getSolConnectionFactory(), true);
     }
 
     @Test
-    public void testGetSolConnectionFactoryByCreds() {
+    void testGetSolConnectionFactoryByCreds() {
         validateSolConnectionFactory(jmsAutoConfBase.getSolConnectionFactory(solaceServiceCredentials), false);
         disableSolaceServiceCredentials();
         validateSolConnectionFactory(jmsAutoConfBase.getSolConnectionFactory(solaceServiceCredentials), false);
     }
 
     @Test
-    public void testGetSolConnectionFactoryById() {
+    void testGetSolConnectionFactoryById() {
         validateSolConnectionFactory(jmsAutoConfBase.getSolConnectionFactory(solaceServiceCredentials.getId()), false);
         disableSolaceServiceCredentials();
         assertNull((jmsAutoConfBase.getSolConnectionFactory(solaceServiceCredentials.getId())));

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationTest.java
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationTest.java
@@ -22,83 +22,88 @@ import com.solace.services.core.model.SolaceServiceCredentials;
 import com.solacesystems.jms.SolConnectionFactory;
 import com.solacesystems.jms.SolConnectionFactoryImpl;
 import com.solacesystems.jms.SpringSolJmsConnectionFactoryCloudFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.jms.core.JmsTemplate;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SystemStubsExtension.class)
 public class SolaceJmsAutoConfigurationTest extends SolaceJmsAutoConfigurationTestBase {
-	public SolaceJmsAutoConfigurationTest() {
-		super(SolaceJmsAutoConfiguration.class);
-	}
 
-	@Test
-	public void defaultNativeConnectionFactory() {
-		load("");
-		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
-		SolConnectionFactoryImpl connectionFactory = this.context
-				.getBean(SolConnectionFactoryImpl.class);
-		assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
+    @SystemStub
+    private EnvironmentVariables environmentVariables;
+
+    public SolaceJmsAutoConfigurationTest() {
+        super(SolaceJmsAutoConfiguration.class);
+    }
+
+    @Test
+    void defaultNativeConnectionFactory() {
+        load("");
+        JmsTemplate jmsTemplate = context.getBean(JmsTemplate.class);
+        SolConnectionFactoryImpl connectionFactory = context.getBean(SolConnectionFactoryImpl.class);
+        assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
         assertEquals("tcp://localhost", connectionFactory.getHost());
         assertEquals("default", connectionFactory.getVPN());
         assertEquals("spring-default-client-username", connectionFactory.getUsername());
         assertEquals("", connectionFactory.getPassword());
         assertFalse(connectionFactory.getDirectTransport());
-	}
+    }
 
-	@Test
-	public void customNativeConnectionFactory() {
-		load("solace.jms.host=192.168.1.80:55500",
-				"solace.jms.clientUsername=bob", "solace.jms.clientPassword=password",
-				"solace.jms.msgVpn=newVpn");
-		JmsTemplate jmsTemplate = this.context.getBean(JmsTemplate.class);
-		SolConnectionFactoryImpl connectionFactory = this.context.getBean(SolConnectionFactoryImpl.class);
-		assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
-		assertEquals("tcp://192.168.1.80:55500", connectionFactory.getHost());
+    @Test
+    void customNativeConnectionFactory() {
+        load("solace.jms.host=192.168.1.80:55500",
+                "solace.jms.clientUsername=bob", "solace.jms.clientPassword=password",
+                "solace.jms.msgVpn=newVpn");
+        JmsTemplate jmsTemplate = context.getBean(JmsTemplate.class);
+        SolConnectionFactoryImpl connectionFactory = context.getBean(SolConnectionFactoryImpl.class);
+        assertEquals(jmsTemplate.getConnectionFactory(), connectionFactory);
+        assertEquals("tcp://192.168.1.80:55500", connectionFactory.getHost());
         assertEquals("newVpn", connectionFactory.getVPN());
         assertEquals("bob", connectionFactory.getUsername());
         assertEquals("password", connectionFactory.getPassword());
         assertFalse(connectionFactory.getDirectTransport());
-	}
+    }
 
     @Test
-    public void externallyLoadedServiceProperties() {
+    void externallyLoadedServiceProperties() {
         // Testing one type of externally loaded service is good enough
         // The loader has its own tests for the other scenarios
         String ENV_SOLCAP_SERVICES = "SOLCAP_SERVICES";
 
-        load(String.format("%s={ \"solace-pubsub\": [%s] }",
-                ENV_SOLCAP_SERVICES, addOneSolaceService(ENV_SOLCAP_SERVICES)));
+        EnvConfig configuration = getOneSolaceService(ENV_SOLCAP_SERVICES);
+        environmentVariables.set(configuration.envName(), configuration.envValue());
+        load(String.format("%s=%s", ENV_SOLCAP_SERVICES, configuration.envValue()));
 
         String solaceManifest = context.getEnvironment().getProperty(ENV_SOLCAP_SERVICES);
         assertNotNull(solaceManifest);
         assertTrue(solaceManifest.contains("solace-pubsub"));
 
-        assertNotNull(this.context.getBean(SolConnectionFactory.class));
-        assertNotNull(this.context.getBean(SpringSolJmsConnectionFactoryCloudFactory.class));
-        assertNotNull(this.context.getBean(SolaceServiceCredentials.class));
+        assertNotNull(context.getBean(SolConnectionFactory.class));
+        assertNotNull(context.getBean(SpringSolJmsConnectionFactoryCloudFactory.class));
+        assertNotNull(context.getBean(SolaceServiceCredentials.class));
     }
 
-	@Test
-	public void noExternallyLoadedServiceProperties() {
-		// Testing one type of externally loaded service is good enough
-		// The loader has its own tests for the other scenarios
-		String ENV_SOLCAP_SERVICES = "SOLCAP_SERVICES";
-		load(String.format("%s={ \"solace-pubsub\": [] }", ENV_SOLCAP_SERVICES));
+    @Test
+    void noExternallyLoadedServiceProperties() {
+        // Testing one type of externally loaded service is good enough
+        // The loader has its own tests for the other scenarios
+        String ENV_SOLCAP_SERVICES = "SOLCAP_SERVICES";
+        load(String.format("%s={ \"solace-pubsub\": [] }", ENV_SOLCAP_SERVICES));
 
-		String solaceManifest = context.getEnvironment().getProperty(ENV_SOLCAP_SERVICES);
-		assertNotNull(solaceManifest);
-		assertTrue(solaceManifest.contains("solace-pubsub"));
+        String solaceManifest = context.getEnvironment().getProperty(ENV_SOLCAP_SERVICES);
+        assertNotNull(solaceManifest);
+        assertTrue(solaceManifest.contains("solace-pubsub"));
 
-		assertNotNull(this.context.getBean(SolConnectionFactory.class));
-		assertNotNull(this.context.getBean(SpringSolJmsConnectionFactoryCloudFactory.class));
-		NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
-				this.context.getBean(SolaceServiceCredentials.class));
-		assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
-	}
+        assertNotNull(context.getBean(SolConnectionFactory.class));
+        assertNotNull(context.getBean(SpringSolJmsConnectionFactoryCloudFactory.class));
+        NoSuchBeanDefinitionException thrown = assertThrows(NoSuchBeanDefinitionException.class, () ->
+                context.getBean(SolaceServiceCredentials.class));
+        assertEquals(SolaceServiceCredentials.class, thrown.getBeanType());
+    }
 }

--- a/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationTestBase.java
+++ b/solace-spring-boot-autoconfigure/solace-jms-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJmsAutoConfigurationTestBase.java
@@ -2,9 +2,7 @@ package com.solace.spring.boot.autoconfigure;
 
 import com.solacesystems.jms.SpringSolJmsConnectionFactoryCloudFactory;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -12,24 +10,26 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.ResolvableType;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.singletonList;
+
 public abstract class SolaceJmsAutoConfigurationTestBase {
-    @Configuration public static class EmptyConfiguration {}
-    @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    @Configuration
+    public static class EmptyConfiguration {
+    }
 
     AnnotationConfigApplicationContext context;
-    private Class<? extends SpringSolJmsConnectionFactoryCloudFactory> configClass;
+    private final Class<? extends SpringSolJmsConnectionFactoryCloudFactory> configClass;
 
     SolaceJmsAutoConfigurationTestBase(Class<? extends SpringSolJmsConnectionFactoryCloudFactory> configClass) {
         this.configClass = configClass;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (this.context != null) {
             this.context.close();
@@ -44,22 +44,22 @@ public abstract class SolaceJmsAutoConfigurationTestBase {
         exCred.put("clientUsername", "sample-client-username");
         exCred.put("clientPassword", "sample-client-password");
         exCred.put("msgVpnName", "sample-msg-vpn");
-        exCred.put("smfHosts", Collections.singletonList("tcp://192.168.1.50:7000"));
+        exCred.put("smfHosts", singletonList("tcp://192.168.1.50:7000"));
         exCred.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.50:7003", "tcps://192.168.1.51:7003"));
-        exCred.put("smfZipHosts", Collections.singletonList("tcp://192.168.1.50:7001"));
-        exCred.put("webMessagingUris", Collections.singletonList("http://192.168.1.50:80"));
-        exCred.put("webMessagingTlsUris", Collections.singletonList("https://192.168.1.50:80"));
-        exCred.put("jmsJndiUris", Collections.singletonList("smf://192.168.1.50:7000"));
+        exCred.put("smfZipHosts", singletonList("tcp://192.168.1.50:7001"));
+        exCred.put("webMessagingUris", singletonList("http://192.168.1.50:80"));
+        exCred.put("webMessagingTlsUris", singletonList("https://192.168.1.50:80"));
+        exCred.put("jmsJndiUris", singletonList("smf://192.168.1.50:7000"));
         exCred.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.50:7003", "smfs://192.168.1.51:7003"));
-        exCred.put("mqttUris", Collections.singletonList("tcp://192.168.1.50:7020"));
+        exCred.put("mqttUris", singletonList("tcp://192.168.1.50:7020"));
         exCred.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021"));
-        exCred.put("mqttWsUris", Collections.singletonList("ws://192.168.1.50:7022"));
+        exCred.put("mqttWsUris", singletonList("ws://192.168.1.50:7022"));
         exCred.put("mqttWssUris", Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023"));
-        exCred.put("restUris", Collections.singletonList("http://192.168.1.50:7018"));
-        exCred.put("restTlsUris", Collections.singletonList("https://192.168.1.50:7019"));
-        exCred.put("amqpUris", Collections.singletonList("amqp://192.168.1.50:7016"));
-        exCred.put("amqpTlsUris", Collections.singletonList("amqps://192.168.1.50:7017"));
-        exCred.put("managementHostnames", Collections.singletonList("vmr-Medium-VMR-0"));
+        exCred.put("restUris", singletonList("http://192.168.1.50:7018"));
+        exCred.put("restTlsUris", singletonList("https://192.168.1.50:7019"));
+        exCred.put("amqpUris", singletonList("amqp://192.168.1.50:7016"));
+        exCred.put("amqpTlsUris", singletonList("amqps://192.168.1.50:7017"));
+        exCred.put("managementHostnames", singletonList("vmr-Medium-VMR-0"));
         exCred.put("managementUsername", "sample-mgmt-username");
         exCred.put("managementPassword", "sample-mgmt-password");
         exCred.put("activeManagementHostname", "vmr-medium-web");
@@ -76,15 +76,11 @@ public abstract class SolaceJmsAutoConfigurationTestBase {
         return exVcapServices;
     }
 
-    String addOneSolaceService(String envName) {
-        // Make a service visible to the Cloud Connector, will end up using the
-        // SolaceMessagingInfoCreator
-
+    EnvConfig getOneSolaceService(String envName) {
         Map<String, Object> services = createOneService();
         JSONObject jsonMapObject = new JSONObject(services);
         String JSONString = jsonMapObject.toString();
-        environmentVariables.set(envName, "{ \"solace-pubsub\": [" + JSONString + "] }");
-        return JSONString;
+        return new EnvConfig(envName, "{ \"solace-pubsub\": [" + JSONString + "] }");
     }
 
     Map<String, Object> createOneUserProvidedService() {
@@ -95,22 +91,22 @@ public abstract class SolaceJmsAutoConfigurationTestBase {
         exCred.put("clientUsername", "sample-client-username2");
         exCred.put("clientPassword", "sample-client-password2");
         exCred.put("msgVpnName", "sample-msg-vpn2");
-        exCred.put("smfHosts", Collections.singletonList("tcp://192.168.1.51:7000"));
+        exCred.put("smfHosts", singletonList("tcp://192.168.1.51:7000"));
         exCred.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.51:7003", "tcps://192.168.1.51:7003"));
-        exCred.put("smfZipHosts", Collections.singletonList("tcp://192.168.1.51:7001"));
-        exCred.put("webMessagingUris", Collections.singletonList("http://192.168.1.51:80"));
-        exCred.put("webMessagingTlsUris", Collections.singletonList("https://192.168.1.51:80"));
-        exCred.put("jmsJndiUris", Collections.singletonList("smf://192.168.1.51:7000"));
+        exCred.put("smfZipHosts", singletonList("tcp://192.168.1.51:7001"));
+        exCred.put("webMessagingUris", singletonList("http://192.168.1.51:80"));
+        exCred.put("webMessagingTlsUris", singletonList("https://192.168.1.51:80"));
+        exCred.put("jmsJndiUris", singletonList("smf://192.168.1.51:7000"));
         exCred.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.51:7003", "smfs://192.168.1.51:7003"));
-        exCred.put("mqttUris", Collections.singletonList("tcp://192.168.1.51:7020"));
+        exCred.put("mqttUris", singletonList("tcp://192.168.1.51:7020"));
         exCred.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.51:7021", "ssl://192.168.1.51:7021"));
-        exCred.put("mqttWsUris", Collections.singletonList("ws://192.168.1.51:7022"));
+        exCred.put("mqttWsUris", singletonList("ws://192.168.1.51:7022"));
         exCred.put("mqttWssUris", Arrays.asList("wss://192.168.1.51:7023", "wss://192.168.1.51:7023"));
-        exCred.put("restUris", Collections.singletonList("http://192.168.1.51:7018"));
-        exCred.put("restTlsUris", Collections.singletonList("https://192.168.1.51:7019"));
-        exCred.put("amqpUris", Collections.singletonList("amqp://192.168.1.51:7016"));
-        exCred.put("amqpTlsUris", Collections.singletonList("amqps://192.168.1.51:7017"));
-        exCred.put("managementHostnames", Collections.singletonList("vmr-Medium-VMR-02"));
+        exCred.put("restUris", singletonList("http://192.168.1.51:7018"));
+        exCred.put("restTlsUris", singletonList("https://192.168.1.51:7019"));
+        exCred.put("amqpUris", singletonList("amqp://192.168.1.51:7016"));
+        exCred.put("amqpTlsUris", singletonList("amqps://192.168.1.51:7017"));
+        exCred.put("managementHostnames", singletonList("vmr-Medium-VMR-02"));
         exCred.put("managementUsername", "sample-mgmt-username2");
         exCred.put("managementPassword", "sample-mgmt-password2");
         exCred.put("activeManagementHostname", "vmr-medium-web2");
@@ -120,20 +116,17 @@ public abstract class SolaceJmsAutoConfigurationTestBase {
         exVcapServices.put("name", "internal-solace-pubsub");
         exVcapServices.put("binding_name", null);
         // no need to check for tags in terms of validation. It's more for
-        exVcapServices.put("tags",
-                Arrays.asList("solace-pubsub"));
-
+        exVcapServices.put("tags", singletonList("solace-pubsub"));
         return exVcapServices;
     }
 
-    String addOneUserProvidedSolaceService(String envName) {
+    EnvConfig getOneUserProvidedSolaceService(String envName) {
         Map<String, Object> services = createOneUserProvidedService();
         JSONObject jsonMapObject = new JSONObject(services);
         String JSONString = jsonMapObject.toString();
-        environmentVariables.set(envName, "{ \"user-provided\": [" + JSONString + "] }");
-        return JSONString;
+        return new EnvConfig(envName, "{ \"user-provided\": [" + JSONString + "] }");
     }
-    
+
     void load(String... environment) {
         load(EmptyConfiguration.class, environment);
     }
@@ -156,9 +149,11 @@ public abstract class SolaceJmsAutoConfigurationTestBase {
                 Class<?> genericClass = resolvableGeneric.getRawClass();
                 if (genericClass != null) testName = testName.append('—').append(genericClass.getSimpleName());
             }
-
             parameters.add(new Object[]{testName.toString(), rawClass});
         }
         return parameters;
+    }
+
+    public record EnvConfig(String envName, String envValue) {
     }
 }

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -21,32 +21,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
 
         <solace.spring.boot.java-autoconf.version>4.2.3-SNAPSHOT</solace.spring.boot.java-autoconf.version>
         <solace.spring.boot.jms-autoconf.version>4.2.3-SNAPSHOT</solace.spring.boot.jms-autoconf.version>
 
-        <solace.jcsmp.version>10.13.1</solace.jcsmp.version>
-        <solace.jms.version>10.13.1</solace.jms.version>
+        <solace.jcsmp.version>10.17.0</solace.jcsmp.version>
+        <solace.jms.version>10.17.0</solace.jms.version>
         <solace.services-info.version>0.4.4</solace.services-info.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!--
-			Workaround for CVE-2021-45046
-			Remove after upgrading to Spring Boot >= 2.6.3
-			 -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>2.17.2</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
+             <dependency>
                 <!-- Import Spring Boot dependency management -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/solace-spring-boot-samples/pom.xml
+++ b/solace-spring-boot-samples/pom.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
+                <version>3.0.0</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.14.2</version>
                 <executions>
                     <execution>
                         <id>set-version</id>

--- a/solace-spring-boot-samples/solace-java-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-java-sample-app/pom.xml
@@ -19,25 +19,16 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.DemoApplication</start-class>
-		<java.version>1.8</java.version>
-		<spring.boot.version>2.6.6</spring.boot.version>
+		<java.version>17</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
+		<spring.boot.version>3.0.1</spring.boot.version>
 		<solace.spring.boot.version>1.2.3-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
-			<!--
-			Workaround for CVE-2021-45046
-			Remove after upgrading to Spring Boot >= 2.6.3
-			 -->
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-bom</artifactId>
-				<version>2.17.2</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
@@ -78,7 +69,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>3.0.0</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -86,18 +77,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
+				<version>3.10.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>${spring.boot.version}</version>
 				<configuration>
-					<fork>true</fork>
 					<skip>false</skip>
 				</configuration>
 				<executions>

--- a/solace-spring-boot-samples/solace-java-sample-app/src/main/java/demo/DemoApplication.java
+++ b/solace-spring-boot-samples/solace-java-sample-app/src/main/java/demo/DemoApplication.java
@@ -18,11 +18,8 @@
  */
 package demo;
 
-import java.util.concurrent.TimeUnit;
-
 import com.solace.services.core.model.SolaceServiceCredentials;
-import com.solacesystems.jcsmp.JCSMPProperties;
-import com.solacesystems.jcsmp.SpringJCSMPFactoryCloudFactory;
+import com.solacesystems.jcsmp.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,14 +28,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.stereotype.Component;
 
-import com.solacesystems.jcsmp.DeliveryMode;
-import com.solacesystems.jcsmp.JCSMPFactory;
-import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.SpringJCSMPFactory;
-import com.solacesystems.jcsmp.TextMessage;
-import com.solacesystems.jcsmp.Topic;
-import com.solacesystems.jcsmp.XMLMessageConsumer;
-import com.solacesystems.jcsmp.XMLMessageProducer;
+import java.util.concurrent.TimeUnit;
 
 @SpringBootApplication
 public class DemoApplication {
@@ -61,8 +51,8 @@ public class DemoApplication {
         @Autowired(required=false) private SolaceServiceCredentials solaceServiceCredentials;
         @Autowired(required=false) private JCSMPProperties jcsmpProperties;
 
-        private DemoMessageConsumer msgConsumer = new DemoMessageConsumer();
-        private DemoPublishEventHandler pubEventHandler = new DemoPublishEventHandler();
+        private final DemoMessageConsumer msgConsumer = new DemoMessageConsumer();
+        private final DemoPublishEventHandler pubEventHandler = new DemoPublishEventHandler();
 
         public void run(String... strings) throws Exception {
             final String msg = "Hello World";

--- a/solace-spring-boot-samples/solace-java-sample-app/src/main/java/demo/DemoMessageConsumer.java
+++ b/solace-spring-boot-samples/solace-java-sample-app/src/main/java/demo/DemoMessageConsumer.java
@@ -18,24 +18,23 @@
  */
 package demo;
 
-import java.util.concurrent.CountDownLatch;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.solacesystems.jcsmp.BytesXMLMessage;
 import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.XMLMessageListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
 
 public class DemoMessageConsumer implements XMLMessageListener {
 
-    private CountDownLatch latch = new CountDownLatch(1);
+    private final CountDownLatch latch = new CountDownLatch(1);
     private static final Logger logger = LoggerFactory.getLogger(DemoMessageConsumer.class);
 
     public void onReceive(BytesXMLMessage msg) {
-        if (msg instanceof TextMessage) {
-            logger.info("============= TextMessage received: " + ((TextMessage) msg).getText());
+        if (msg instanceof TextMessage tm) {
+            logger.info("============= TextMessage received: " + tm.getText());
         } else {
             logger.info("============= Message received.");
         }

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/pom.xml
@@ -19,25 +19,16 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jndidemo.JndiDemoApplication</start-class>
-		<java.version>1.8</java.version>
-		<spring.boot.version>2.6.6</spring.boot.version>
+		<java.version>17</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
+		<spring.boot.version>3.0.1</spring.boot.version>
 		<solace.spring.boot.bom.version>1.2.3-SNAPSHOT</solace.spring.boot.bom.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
-			<!--
-			Workaround for CVE-2021-45046
-			Remove after upgrading to Spring Boot >= 2.6.3
-			 -->
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-bom</artifactId>
-				<version>2.17.2</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
@@ -79,7 +70,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>3.0.0</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -87,18 +78,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
+				<version>3.10.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>${spring.boot.version}</version>
 				<configuration>
-					<fork>true</fork>
 					<skip>false</skip>
 				</configuration>
 				<executions>

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/src/main/java/jndidemo/JndiDemoApplication.java
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/src/main/java/jndidemo/JndiDemoApplication.java
@@ -1,6 +1,5 @@
 package jndidemo;
 
-import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,58 +14,60 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 @SpringBootApplication
 public class JndiDemoApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(JndiDemoApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(JndiDemoApplication.class, args);
+    }
 
-	@Service
-	static class MessageProducer implements CommandLineRunner {
+    @Service
+    static class MessageProducer implements CommandLineRunner {
 
-		private static final Logger logger = LoggerFactory.getLogger(MessageProducer.class);
+        private static final Logger logger = LoggerFactory.getLogger(MessageProducer.class);
 
-		@Autowired
-		private JmsTemplate producerJmsTemplate;
+        @Autowired
+        private JmsTemplate producerJmsTemplate;
 
-		// Examples of other options to get JmsTemplate in a cloud environment with possibly multiple providers available:
-		// Use this to access JmsTemplate of the first service found or look up a specific one by SolaceServiceCredentials
-		// @Autowired private SpringSolJmsConnectionFactoryCloudFactory springSolJmsConnectionFactoryCloudFactory;
-		// @Autowired private SolaceServiceCredentials solaceServiceCredentials;
-		// For backwards compatibility:
-		// @Autowired(required=false) private SolaceMessagingInfo solaceMessagingInfo;
+        // Examples of other options to get JmsTemplate in a cloud environment with possibly multiple providers available:
+        // Use this to access JmsTemplate of the first service found or look up a specific one by SolaceServiceCredentials
+        // @Autowired private SpringSolJmsConnectionFactoryCloudFactory springSolJmsConnectionFactoryCloudFactory;
+        // @Autowired private SolaceServiceCredentials solaceServiceCredentials;
+        // For backwards compatibility:
+        // @Autowired(required=false) private SolaceMessagingInfo solaceMessagingInfo;
 
-		@Value("${solace.jms.demoProducerQueueJndiName}")
-		private String queueJndiName;
+        @Value("${solace.jms.demoProducerQueueJndiName}")
+        private String queueJndiName;
 
-		public void run(String... strings) throws Exception {
-			String msg = "Hello World";
-			logger.info("============= Sending " + msg);
-			this.producerJmsTemplate.convertAndSend(queueJndiName, msg);
-		}
-	}
+        public void run(String... strings) {
+            String msg = "Hello World";
+            logger.info("============= Sending " + msg);
+            this.producerJmsTemplate.convertAndSend(queueJndiName, msg);
+        }
+    }
 
-	@Component
-	static class MessageHandler {
+    @Component
+    static class MessageHandler {
 
-		private static final Logger logger = LoggerFactory.getLogger(MessageHandler.class);
+        private static final Logger logger = LoggerFactory.getLogger(MessageHandler.class);
 
-		// Retrieve the name of the queue from the application.properties file
-		@JmsListener(destination = "${solace.jms.demoConsumerQueueJndiName}", containerFactory = "cFactory")
-		public void processMsg(Message<?> msg) {
-			StringBuffer msgAsStr = new StringBuffer("============= Received \nHeaders:");
-			MessageHeaders hdrs = msg.getHeaders();
-			msgAsStr.append("\nUUID: " + hdrs.getId());
-			msgAsStr.append("\nTimestamp: " + hdrs.getTimestamp());
-			Iterator<String> keyIter = hdrs.keySet().iterator();
-			while (keyIter.hasNext()) {
-				String key = keyIter.next();
-				msgAsStr.append("\n" + key + ": " + hdrs.get(key));
-			}
-			msgAsStr.append("\nPayload: " + msg.getPayload());
-			logger.info(msgAsStr.toString());
-		}
-	}
+        // Retrieve the name of the queue from the application.properties file
+        @JmsListener(destination = "${solace.jms.demoConsumerQueueJndiName}", containerFactory = "cFactory")
+        public void processMsg(Message<?> msg) {
+            StringBuilder msgAsStr = new StringBuilder("============= Received \nHeaders:");
+            MessageHeaders hdrs = msg.getHeaders();
+            msgAsStr.append("\nUUID: ").append(hdrs.getId());
+            msgAsStr.append("\nTimestamp: ").append(hdrs.getTimestamp());
+            for (Map.Entry<String, Object> entry : hdrs.entrySet()) {
+                msgAsStr.append("\n").append(entry.getKey()).append(": ").append(entry.getValue());
+            }
+            msgAsStr.append("\nPayload: ").append(msg.getPayload());
+            if (!msgAsStr.isEmpty()) {
+                logger.info(msgAsStr.toString());
+            }
+        }
+    }
 
 }

--- a/solace-spring-boot-samples/solace-jms-sample-app-jndi/src/main/java/jndidemo/JndiProducerConfiguration.java
+++ b/solace-spring-boot-samples/solace-jms-sample-app-jndi/src/main/java/jndidemo/JndiProducerConfiguration.java
@@ -1,8 +1,6 @@
 package jndidemo;
 
-import javax.jms.ConnectionFactory;
-import javax.naming.NamingException;
-
+import jakarta.jms.ConnectionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +10,8 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.destination.JndiDestinationResolver;
 import org.springframework.jndi.JndiObjectFactoryBean;
 import org.springframework.jndi.JndiTemplate;
+
+import javax.naming.NamingException;
 
 @Configuration
 public class JndiProducerConfiguration {
@@ -28,37 +28,35 @@ public class JndiProducerConfiguration {
         factoryBean.setJndiName(connectionFactoryJndiName);
         // following ensures all the properties are injected before returning
         try {
-			factoryBean.afterPropertiesSet();
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-		} catch (NamingException e) {
-			e.printStackTrace();
-		}
+            factoryBean.afterPropertiesSet();
+        } catch (IllegalArgumentException | NamingException e) {
+            e.printStackTrace();
+        }
         return factoryBean;
     }
 
-	private CachingConnectionFactory producerCachingConnectionFactory() {
-		CachingConnectionFactory ccf = new CachingConnectionFactory((ConnectionFactory) producerConnectionFactory().getObject());
-		ccf.setSessionCacheSize(10);
-		return ccf;
-	}
+    private CachingConnectionFactory producerCachingConnectionFactory() {
+        CachingConnectionFactory ccf = new CachingConnectionFactory((ConnectionFactory) producerConnectionFactory().getObject());
+        ccf.setSessionCacheSize(10);
+        return ccf;
+    }
 
     // Configure the destination resolver for the producer:
     // Here we are using JndiDestinationResolver for JNDI destinations
     // Other options include using DynamicDestinationResolver for non-JNDI destinations
     private JndiDestinationResolver producerJndiDestinationResolver() {
-    	JndiDestinationResolver jdr = new JndiDestinationResolver();
+        JndiDestinationResolver jdr = new JndiDestinationResolver();
         jdr.setCache(true);
         jdr.setJndiTemplate(jndiTemplate);
         return jdr;
     }
 
-	@Bean
-	public JmsTemplate producerJmsTemplate() {
-		JmsTemplate jt = new JmsTemplate(producerCachingConnectionFactory());
-		jt.setDeliveryPersistent(true);
-		jt.setDestinationResolver(producerJndiDestinationResolver());
-		return jt;
-	}
+    @Bean
+    public JmsTemplate producerJmsTemplate() {
+        JmsTemplate jt = new JmsTemplate(producerCachingConnectionFactory());
+        jt.setDeliveryPersistent(true);
+        jt.setDestinationResolver(producerJndiDestinationResolver());
+        return jt;
+    }
 
 }

--- a/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
+++ b/solace-spring-boot-samples/solace-jms-sample-app/pom.xml
@@ -19,24 +19,16 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>jmsdemo.DemoApplication</start-class>
-		<java.version>1.8</java.version>
-		<spring.boot.version>2.6.6</spring.boot.version>
+		<java.version>17</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
+		<spring.boot.version>3.0.1</spring.boot.version>
 		<solace.spring.boot.version>1.2.3-SNAPSHOT</solace.spring.boot.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
-			<!--
-			Workaround for CVE-2021-45046
-			Remove after upgrading to Spring Boot >= 2.6.3
-			 -->
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-bom</artifactId>
-				<version>2.17.2</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
@@ -79,7 +71,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>3.0.0</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -87,18 +79,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
+				<version>3.10.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>${spring.boot.version}</version>
 				<configuration>
-					<fork>true</fork>
 					<skip>false</skip>
 				</configuration>
 				<executions>

--- a/solace-spring-boot-samples/solace-jms-sample-app/src/main/java/jmsdemo/ConsumerConfiguration.java
+++ b/solace-spring-boot-samples/solace-jms-sample-app/src/main/java/jmsdemo/ConsumerConfiguration.java
@@ -1,11 +1,6 @@
 package jmsdemo;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-
-import javax.jms.ConnectionFactory;
-
+import jakarta.jms.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +9,10 @@ import org.springframework.jms.annotation.EnableJms;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ErrorHandler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 @EnableJms
 @Configuration
@@ -31,20 +30,14 @@ public class ConsumerConfiguration {
     }
 
     @Service
-    public class DemoErrorHandler implements ErrorHandler{   
+    public static class DemoErrorHandler implements ErrorHandler {
 
         public void handleError(Throwable t) {
-        	ByteArrayOutputStream os = new ByteArrayOutputStream();
-        	PrintStream ps = new PrintStream(os);
-        	t.printStackTrace(ps);
-        	try {
-				String output = os.toString("UTF8");
-	            logger.error("============= Error processing message: " + t.getMessage()+"\n"+output);
-			} catch (UnsupportedEncodingException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
- 
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(os);
+            t.printStackTrace(ps);
+            String output = os.toString(StandardCharsets.UTF_8);
+            logger.error("============= Error processing message: " + t.getMessage() + "\n" + output);
         }
     }
 

--- a/solace-spring-boot-samples/solace-jms-sample-app/src/main/java/jmsdemo/DemoApplication.java
+++ b/solace-spring-boot-samples/solace-jms-sample-app/src/main/java/jmsdemo/DemoApplication.java
@@ -1,6 +1,5 @@
 package jmsdemo;
 
-import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +13,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @SpringBootApplication
 public class DemoApplication {
@@ -41,7 +42,7 @@ public class DemoApplication {
         @Value("${solace.jms.demoQueueName}")
         private String queueName;
 
-        public void run(String... strings) throws Exception {
+        public void run(String... strings) {
             String msg = "Hello World";
             logger.info("============= Sending " + msg);
             this.jmsTemplate.convertAndSend(queueName, msg);
@@ -56,17 +57,17 @@ public class DemoApplication {
         // Retrieve the name of the queue from the application.properties file
         @JmsListener(destination = "${solace.jms.demoQueueName}", containerFactory = "cFactory", concurrency = "2")
         public void processMsg(Message<?> msg) {
-        	StringBuffer msgAsStr = new StringBuffer("============= Received \nHeaders:");
-        	MessageHeaders hdrs = msg.getHeaders();
-        	msgAsStr.append("\nUUID: "+hdrs.getId());
-        	msgAsStr.append("\nTimestamp: "+hdrs.getTimestamp());
-        	Iterator<String> keyIter = hdrs.keySet().iterator();
-        	while (keyIter.hasNext()) {
-        		String key = keyIter.next();
-            	msgAsStr.append("\n"+key+": "+hdrs.get(key));
-        	}
-        	msgAsStr.append("\nPayload: "+msg.getPayload());
-            logger.info(msgAsStr.toString());
+            StringBuilder msgAsStr = new StringBuilder("============= Received \nHeaders:");
+            MessageHeaders hdrs = msg.getHeaders();
+            msgAsStr.append("\nUUID: ").append(hdrs.getId());
+            msgAsStr.append("\nTimestamp: ").append(hdrs.getTimestamp());
+            for (Map.Entry<String, Object> entry : hdrs.entrySet()) {
+                msgAsStr.append("\n").append(entry.getKey()).append(": ").append(entry.getValue());
+            }
+            msgAsStr.append("\nPayload: ").append(msg.getPayload());
+            if (!msgAsStr.isEmpty()) {
+                logger.info(msgAsStr.toString());
+            }
         }
     }
 

--- a/solace-spring-boot-samples/solace-jms-sample-app/src/main/java/jmsdemo/ProducerConfiguration.java
+++ b/solace-spring-boot-samples/solace-jms-sample-app/src/main/java/jmsdemo/ProducerConfiguration.java
@@ -1,23 +1,19 @@
 package jmsdemo;
 
-import javax.jms.ConnectionFactory;
-
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.jms.ConnectionFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
 
+
 @Configuration
 public class ProducerConfiguration {
 
-	@Autowired
-	private ConnectionFactory connectionFactory;
-
-	// Example use of CachingConnectionFactory for the producer
-	@Bean
-	public JmsTemplate jmsTemplate() {
-		CachingConnectionFactory ccf = new CachingConnectionFactory(connectionFactory);
-		return new JmsTemplate(ccf);
-	}
+    // Example use of CachingConnectionFactory for the producer
+    @Bean
+    public JmsTemplate jmsTemplate(ConnectionFactory connectionFactory) {
+        CachingConnectionFactory ccf = new CachingConnectionFactory(connectionFactory);
+        return new JmsTemplate(ccf);
+    }
 }


### PR DESCRIPTION
Spring Boot 3 support - adding missing dependencies JUnit 5 support

sol-jms needs to support JMS 2.0, For now it's using 

        <dependency>
            <groupId>org.apache.geronimo.specs</groupId>
            <artifactId>geronimo-jms_1.1_spec</artifactId>
            <scope>compile</scope>
        </dependency>

We can use Spring Boot 3 for Java implementation only (https://github.com/infoShare/solace-spring-boot/tree/java-jms-separation)