### PR TITLE
Removed system-rules maven dependency. 

### DIFF
--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -43,6 +43,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -39,11 +39,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
-			<groupId>com.github.stefanbirkner</groupId>
-			<artifactId>system-rules</artifactId>
-			<version>1.19.0</version>
-			<scope>test</scope>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The only reason for including it, is the transient dependency to junit 4.