### PR TITLE
Adding Health Indicators and Health Contributors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <repoName>SolaceProducts</repoName>
 
     <!-- This is the version of Spring Boot we have targeted for this build -->
-    <spring.boot.version>3.0.6</spring.boot.version>
+    <spring.boot.version>3.1.4</spring.boot.version>
 
     <solace.spring.boot.java-starter.version>5.0.1-SNAPSHOT
     </solace.spring.boot.java-starter.version>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -24,6 +24,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
@@ -44,6 +48,11 @@
 			<artifactId>system-rules</artifactId>
 			<version>1.19.0</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.30</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -24,7 +24,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
+			<artifactId>spring-boot-actuator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/base/SolaceHealthIndicator.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/base/SolaceHealthIndicator.java
@@ -42,7 +42,7 @@ public class SolaceHealthIndicator implements HealthIndicator {
 	protected <T> void healthReconnecting(@Nullable T eventArgs) {
 		try {
 			writeLock.lock();
-			health = addSessionEventDetails(Health.status(STATUS_RECONNECTING), eventArgs).build();
+			health = addEventDetails(Health.status(STATUS_RECONNECTING), eventArgs).build();
 			logDebugStatus(STATUS_RECONNECTING);
 		} finally {
 			writeLock.unlock();
@@ -52,14 +52,14 @@ public class SolaceHealthIndicator implements HealthIndicator {
 	protected <T> void healthDown(@Nullable T eventArgs) {
 		try {
 			writeLock.lock();
-			health = addSessionEventDetails(Health.down(), eventArgs).build();
+			health = addEventDetails(Health.down(), eventArgs).build();
 			logDebugStatus(String.valueOf(Status.DOWN));
 		} finally {
 			writeLock.unlock();
 		}
 	}
 
-	public <T> Health.Builder addSessionEventDetails(Health.Builder builder, @Nullable T eventArgs) {
+	public <T> Health.Builder addEventDetails(Health.Builder builder, @Nullable T eventArgs) {
 		if (eventArgs == null) {
 			return builder;
 		}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/base/SolaceHealthIndicator.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/base/SolaceHealthIndicator.java
@@ -1,0 +1,87 @@
+package com.health.base;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.lang.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SolaceHealthIndicator implements HealthIndicator {
+	private static final String STATUS_RECONNECTING = "RECONNECTING";
+	private static final String INFO = "info";
+	private static final String RESPONSE_CODE = "responseCode";
+	private volatile Health health;
+	private final ReentrantLock writeLock = new ReentrantLock();
+	private static final Log logger = LogFactory.getLog(SolaceHealthIndicator.class);
+
+	private static void logDebugStatus(String status) {
+		if (logger.isDebugEnabled()) {
+			logger.debug(String.format("Solace connection/flow status is %s", status));
+		}
+	}
+	protected void healthUp() {
+		try {
+			writeLock.lock();
+			health = Health.up().build();
+			logDebugStatus(String.valueOf(Status.UP));
+		} finally {
+			writeLock.unlock();
+		}
+	}
+	protected <T> void healthReconnecting(@Nullable T eventArgs) {
+		try {
+			writeLock.lock();
+			health = addSessionEventDetails(Health.status(STATUS_RECONNECTING), eventArgs).build();
+			logDebugStatus(STATUS_RECONNECTING);
+		} finally {
+			writeLock.unlock();
+		}
+	}
+
+	protected <T> void healthDown(@Nullable T eventArgs) {
+		try {
+			writeLock.lock();
+			health = addSessionEventDetails(Health.down(), eventArgs).build();
+			logDebugStatus(String.valueOf(Status.DOWN));
+		} finally {
+			writeLock.unlock();
+		}
+	}
+
+	public <T> Health.Builder addSessionEventDetails(Health.Builder builder, @Nullable T eventArgs) {
+		if (eventArgs == null) {
+			return builder;
+		}
+
+		try {
+			Optional.ofNullable(eventArgs.getClass().getMethod("getException").invoke(eventArgs))
+					.ifPresent(ex -> builder.withException((Throwable) ex));
+			Optional.of(eventArgs.getClass().getMethod("getResponseCode").invoke(eventArgs))
+					.filter(c -> ((int) c) != 0)
+					.ifPresent(c -> builder.withDetail(RESPONSE_CODE, c));
+			Optional.ofNullable(eventArgs.getClass().getMethod("getInfo").invoke(eventArgs))
+					.filter(t -> String.valueOf(t).isBlank())
+					.ifPresent(info -> builder.withDetail(INFO, info));
+		} catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+			throw new RuntimeException(e);
+		}
+
+		return builder;
+	}
+
+	@Override
+	public Health health() {
+		return health;
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceBinderHealthContributor.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceBinderHealthContributor.java
@@ -1,0 +1,49 @@
+package com.health.contributors;
+
+import com.health.indicators.SolaceSessionHealthIndicator;
+import org.springframework.boot.actuate.health.CompositeHealthContributor;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.health.NamedContributor;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class SolaceBinderHealthContributor implements CompositeHealthContributor {
+	private final SolaceSessionHealthIndicator solaceSessionHealthIndicator;
+	private final SolaceBindingsHealthContributor solaceBindingsHealthContributor;
+
+	private static final String CONNECTION = "connection";
+	private static final String BINDINGS = "bindings";
+
+	public SolaceBinderHealthContributor(SolaceSessionHealthIndicator solaceSessionHealthIndicator,
+	                                     SolaceBindingsHealthContributor solaceBindingsHealthContributor) {
+		this.solaceSessionHealthIndicator = solaceSessionHealthIndicator;
+		this.solaceBindingsHealthContributor = solaceBindingsHealthContributor;
+	}
+
+	@Override
+	public HealthContributor getContributor(String name) {
+		return switch (name) {
+			case CONNECTION -> solaceSessionHealthIndicator;
+			case BINDINGS -> solaceBindingsHealthContributor;
+			default -> null;
+		};
+	}
+
+	public SolaceSessionHealthIndicator getSolaceSessionHealthIndicator() {
+		return solaceSessionHealthIndicator;
+	}
+
+	public SolaceBindingsHealthContributor getSolaceBindingsHealthContributor() {
+		return solaceBindingsHealthContributor;
+	}
+
+	@Override
+	public Iterator<NamedContributor<HealthContributor>> iterator() {
+		List<NamedContributor<HealthContributor>> contributors = new ArrayList<>();
+		contributors.add(NamedContributor.of(CONNECTION, solaceSessionHealthIndicator));
+		contributors.add(NamedContributor.of(BINDINGS, solaceBindingsHealthContributor));
+		return contributors.iterator();
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceBindingHealthContributor.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceBindingHealthContributor.java
@@ -1,0 +1,32 @@
+package com.health.contributors;
+
+import lombok.Getter;
+import org.springframework.boot.actuate.health.CompositeHealthContributor;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.health.NamedContributor;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+@Getter
+public class SolaceBindingHealthContributor implements CompositeHealthContributor {
+	private final SolaceFlowsHealthContributor solaceFlowsHealthContributor;
+	private static final String FLOWS_CONTRIBUTOR_KEY = "flows";
+
+	public SolaceBindingHealthContributor(SolaceFlowsHealthContributor solaceFlowsHealthContributor) {
+		this.solaceFlowsHealthContributor = solaceFlowsHealthContributor;
+	}
+
+	@Override
+	public HealthContributor getContributor(String name) {
+		return name.equals(FLOWS_CONTRIBUTOR_KEY) ? solaceFlowsHealthContributor : null;
+	}
+
+	@Override
+	public Iterator<NamedContributor<HealthContributor>> iterator() {
+		Set<NamedContributor<HealthContributor>> contributors = Collections.singleton(
+				NamedContributor.of(FLOWS_CONTRIBUTOR_KEY, solaceFlowsHealthContributor));
+		return contributors.iterator();
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceBindingsHealthContributor.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceBindingsHealthContributor.java
@@ -1,0 +1,34 @@
+package com.health.contributors;
+
+import org.springframework.boot.actuate.health.CompositeHealthContributor;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.health.NamedContributor;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class SolaceBindingsHealthContributor implements CompositeHealthContributor {
+	private final Map<String, SolaceBindingHealthContributor> bindingHealthContributor = new HashMap<>();
+
+	public void addBindingContributor(String bindingName, SolaceBindingHealthContributor solaceBindingHealthContributor) {
+		this.bindingHealthContributor.put(bindingName, solaceBindingHealthContributor);
+	}
+
+	public void removeBindingContributor(String bindingName) {
+		bindingHealthContributor.remove(bindingName);
+	}
+
+	@Override
+	public HealthContributor getContributor(String bindingName) {
+		return bindingHealthContributor.get(bindingName);
+	}
+
+	@Override
+	public Iterator<NamedContributor<HealthContributor>> iterator() {
+		return bindingHealthContributor.entrySet()
+				.stream()
+				.map((entry) -> NamedContributor.of(entry.getKey(), (HealthContributor) entry.getValue()))
+				.iterator();
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceFlowsHealthContributor.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/contributors/SolaceFlowsHealthContributor.java
@@ -1,0 +1,35 @@
+package com.health.contributors;
+
+import com.health.indicators.SolaceFlowHealthIndicator;
+import org.springframework.boot.actuate.health.CompositeHealthContributor;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.health.NamedContributor;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class SolaceFlowsHealthContributor implements CompositeHealthContributor {
+	private final Map<String, SolaceFlowHealthIndicator> flowHealthContributor = new HashMap<>();
+
+	public void addFlowContributor(String bindingName, SolaceFlowHealthIndicator flowHealthIndicator) {
+		flowHealthContributor.put(bindingName, flowHealthIndicator);
+	}
+
+	public void removeFlowContributor(String bindingName) {
+		flowHealthContributor.remove(bindingName);
+	}
+
+	@Override
+	public HealthContributor getContributor(String name) {
+		return flowHealthContributor.get(name);
+	}
+
+	@Override
+	public Iterator<NamedContributor<HealthContributor>> iterator() {
+		return flowHealthContributor.entrySet()
+				.stream()
+				.map((entry) -> NamedContributor.of(entry.getKey(), (HealthContributor) entry.getValue()))
+				.iterator();
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/indicators/SolaceFlowHealthIndicator.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/indicators/SolaceFlowHealthIndicator.java
@@ -1,0 +1,25 @@
+package com.health.indicators;
+
+import com.health.base.SolaceHealthIndicator;
+import com.solacesystems.jcsmp.FlowEventArgs;
+import org.springframework.lang.Nullable;
+
+public class SolaceFlowHealthIndicator extends SolaceHealthIndicator {
+	public void up() {
+		super.healthUp();
+	}
+
+	public void reconnecting(@Nullable FlowEventArgs eventArgs) {
+		super.healthReconnecting(eventArgs);
+	}
+
+	public void down(@Nullable FlowEventArgs eventArgs) {
+		super.healthDown(eventArgs);
+	}
+
+	@Deprecated
+	public void down(@Nullable FlowEventArgs eventArgs, boolean resetReconnectCount) {
+		super.healthDown(eventArgs);
+	}
+
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/indicators/SolaceSessionHealthIndicator.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/main/java/com/health/indicators/SolaceSessionHealthIndicator.java
@@ -1,0 +1,24 @@
+package com.health.indicators;
+
+import com.health.base.SolaceHealthIndicator;
+import com.solacesystems.jcsmp.SessionEventArgs;
+import org.springframework.lang.Nullable;
+
+public class SolaceSessionHealthIndicator extends SolaceHealthIndicator {
+	public void up() {
+		super.healthUp();
+	}
+
+	public void reconnecting(@Nullable SessionEventArgs eventArgs) {
+		super.healthReconnecting(eventArgs);
+	}
+
+	public void down(@Nullable SessionEventArgs eventArgs) {
+		super.healthDown(eventArgs);
+	}
+
+	@Deprecated
+	public void down(@Nullable SessionEventArgs eventArgs, boolean resetReconnectCount) {
+		super.healthDown(eventArgs);
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/health/base/SolaceHealthIndicatorTest.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/health/base/SolaceHealthIndicatorTest.java
@@ -1,0 +1,64 @@
+package com.health.base;
+
+import com.solacesystems.jcsmp.FlowEvent;
+import com.solacesystems.jcsmp.FlowEventArgs;
+import com.solacesystems.jcsmp.SessionEvent;
+import com.solacesystems.jcsmp.SessionEventArgs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolaceHealthIndicatorTest {
+
+	private SolaceHealthIndicator solaceHealthIndicator;
+
+	@BeforeEach
+	void setUp() {
+		this.solaceHealthIndicator = new SolaceHealthIndicator();
+	}
+
+	@Test
+	void healthUp() {
+		this.solaceHealthIndicator.healthUp();
+		assertEquals(this.solaceHealthIndicator.getHealth(), Health.up().build());
+	}
+
+	@Test
+	void healthReconnecting() {
+		this.solaceHealthIndicator.healthReconnecting(null);
+		assertEquals(this.solaceHealthIndicator.getHealth(), Health.status("RECONNECTING").build());
+	}
+
+	@Test
+	void healthDown() {
+		this.solaceHealthIndicator.healthDown(null);
+		assertEquals(this.solaceHealthIndicator.getHealth(), Health.down().build());
+	}
+
+	@Test
+	void addFlowEventDetails() {
+		// as SessionEventArgs constructor has package level access modifier, we have to test with FlowEventArgs only
+		FlowEventArgs flowEventArgs = new FlowEventArgs(FlowEvent.FLOW_DOWN, "String_infoStr",
+				new Exception("Test Exception"), 500);
+		Health health = this.solaceHealthIndicator.addEventDetails(Health.down(),flowEventArgs).build();
+
+		assertEquals(health.getStatus(), Status.DOWN);
+		assertEquals(health.getDetails().get("error"), "java.lang.Exception: Test Exception");
+		assertEquals(health.getDetails().get("responseCode"), 500);
+	}
+
+	@Test
+	void getHealth() {
+		this.solaceHealthIndicator.setHealth(Health.up().build());
+		assertEquals(this.solaceHealthIndicator.getHealth(), Health.up().build());
+	}
+
+	@Test
+	void setHealth() {
+		this.solaceHealthIndicator.setHealth(Health.down().build());
+		assertEquals(this.solaceHealthIndicator.getHealth(), Health.down().build());
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/health/indicators/SolaceFlowHealthIndicatorTest.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/health/indicators/SolaceFlowHealthIndicatorTest.java
@@ -1,0 +1,50 @@
+package com.health.indicators;
+
+import com.health.base.SolaceHealthIndicator;
+import com.solacesystems.jcsmp.FlowEvent;
+import com.solacesystems.jcsmp.FlowEventArgs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolaceFlowHealthIndicatorTest {
+
+	private SolaceFlowHealthIndicator solaceHealthIndicator;
+
+	@BeforeEach
+	void setUp() {
+		this.solaceHealthIndicator = new SolaceFlowHealthIndicator();
+	}
+
+	@Test
+	void up() {
+		this.solaceHealthIndicator.up();
+		assertEquals(this.solaceHealthIndicator.getHealth(), Health.up().build());
+	}
+
+	@Test
+	void reconnecting() {
+		FlowEventArgs flowEventArgs = new FlowEventArgs(FlowEvent.FLOW_RECONNECTING, "String_infoStr",
+				new Exception("Test Exception"), 500);
+		this.solaceHealthIndicator.reconnecting(flowEventArgs);
+		assertEquals(this.solaceHealthIndicator.getHealth().getStatus(), Health.status("RECONNECTING").build().getStatus());
+		assertEquals(this.solaceHealthIndicator.getHealth().getDetails().get("error"), "java.lang.Exception: Test Exception");
+		assertEquals(this.solaceHealthIndicator.getHealth().getDetails().get("responseCode"), 500);
+
+	}
+
+	@Test
+	void down() {
+		FlowEventArgs flowEventArgs = new FlowEventArgs(FlowEvent.FLOW_DOWN, "String_infoStr",
+				new Exception("Test Exception"), 500);
+		this.solaceHealthIndicator.down(flowEventArgs);
+		assertEquals(this.solaceHealthIndicator.getHealth().getStatus(), Status.DOWN);
+		assertEquals(this.solaceHealthIndicator.getHealth().getDetails().get("error"), "java.lang.Exception: Test Exception");
+		assertEquals(this.solaceHealthIndicator.getHealth().getDetails().get("responseCode"), 500);
+	}
+}

--- a/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/health/indicators/SolaceSessionHealthIndicatorTest.java
+++ b/solace-spring-boot-autoconfigure/solace-java-spring-boot-autoconfigure/src/test/java/com/health/indicators/SolaceSessionHealthIndicatorTest.java
@@ -1,0 +1,38 @@
+package com.health.indicators;
+
+import com.solacesystems.jcsmp.FlowEvent;
+import com.solacesystems.jcsmp.FlowEventArgs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolaceSessionHealthIndicatorTest {
+
+	private SolaceSessionHealthIndicator solaceHealthIndicator;
+
+	@BeforeEach
+	void setUp() {
+		this.solaceHealthIndicator = new SolaceSessionHealthIndicator();
+	}
+
+	@Test
+	void up() {
+		this.solaceHealthIndicator.up();
+		assertEquals(this.solaceHealthIndicator.getHealth(), Health.up().build());
+	}
+
+	@Test
+	void reconnecting() {
+		this.solaceHealthIndicator.reconnecting(null);
+		assertEquals(this.solaceHealthIndicator.getHealth().getStatus(), Health.status("RECONNECTING").build().getStatus());
+	}
+
+	@Test
+	void down() {
+		this.solaceHealthIndicator.down(null);
+		assertEquals(this.solaceHealthIndicator.getHealth().getStatus(), Status.DOWN);
+	}
+}

--- a/solace-spring-boot-parent/pom.xml
+++ b/solace-spring-boot-parent/pom.xml
@@ -35,6 +35,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- snakeyaml vulnerabilites -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
+            </dependency>
             <!--
 			Workaround for CVE-2021-45046
 			Remove after upgrading to Spring Boot >= 2.6.3


### PR DESCRIPTION
This PR adds new functionality of health indicators and health contributors in arrange to build a logical system showing health of all components in a visualized tree manner.

These changes do not propagate any status aggregation for nested components, i.e. if any of the status will be changed from UP to something else - this will be raised up to the root, as the intention for these components is to keep them as simple as possible.

All other functionality, including but not limited to the status aggregation and adding additional rules for statues, should be considered outside this repository.