### PR TITLE
Use same_content_newer for GitHub workflow skip detection

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5.3.1
         with:
-          concurrent_skipping: same_content
+          concurrent_skipping: same_content_newer
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   build:


### PR DESCRIPTION
Change `concurrent_skipping` to use `same_content_newer` to guarantee that at least one workflow will run.